### PR TITLE
Change level_downsamples from stored attribute to computed property

### DIFF
--- a/examples/OMETiff-convertor-demo.ipynb
+++ b/examples/OMETiff-convertor-demo.ipynb
@@ -125,8 +125,8 @@
       "level_count: 3\n",
       "dimensions: (2220, 2967)\n",
       "level_dimensions: ((2220, 2967), (387, 463), (1280, 431))\n",
-      "level_downsamples: None\n",
-      "level_info: [LevelInfo(level=0, shape=(2220, 2967)), LevelInfo(level=1, shape=(387, 463)), LevelInfo(level=2, shape=(1280, 431))]\n"
+      "level_downsamples: (1.0, 6.0723207259698295, 4.30918285962877)\n",
+      "level_info: (LevelInfo(level=0, dimensions=(2220, 2967)), LevelInfo(level=1, dimensions=(387, 463)), LevelInfo(level=2, dimensions=(1280, 431)))\n"
      ]
     }
    ],

--- a/examples/OMEZarr-convertor-demo.ipynb
+++ b/examples/OMEZarr-convertor-demo.ipynb
@@ -125,8 +125,8 @@
       "level_count: 3\n",
       "dimensions: (2220, 2967)\n",
       "level_dimensions: ((2220, 2967), (387, 463), (1280, 431))\n",
-      "level_downsamples: None\n",
-      "level_info: [LevelInfo(level=0, shape=(2220, 2967)), LevelInfo(level=1, shape=(387, 463)), LevelInfo(level=2, shape=(1280, 431))]\n"
+      "level_downsamples: (1.0, 6.0723207259698295, 4.30918285962877)\n",
+      "level_info: (LevelInfo(level=0, dimensions=(2220, 2967)), LevelInfo(level=1, dimensions=(387, 463)), LevelInfo(level=2, dimensions=(1280, 431)))\n"
      ]
     }
    ],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -73,8 +73,8 @@ def get_CMU_1_SMALL_REGION_schemas():
     ]
 
 
-def check_level_info(num, level_info):
-    assert level_info.level == num
+def check_level_info(level, level_info):
+    assert level_info.level == level
     assert tiledb.object_type(level_info.uri) == "array"
     assert isinstance(level_info.dimensions, tuple)
     assert all(isinstance(dim, int) for dim in level_info.dimensions)

--- a/tests/integration/converters/test_ome.py
+++ b/tests/integration/converters/test_ome.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 
+import numpy as np
 import pytest
 import tiledb
 
@@ -34,6 +35,10 @@ def test_ome(format_path):
     assert t.dimensions == (2220, 2967)
     assert t.level_dimensions == ((2220, 2967), (387, 463), (1280, 431))
     assert t.level_downsamples == (1.0, 6.0723207259698295, 4.30918285962877)
+
+    region = t.read_region(level=0, location=(100, 100), size=(300, 400))
+    assert isinstance(region, np.ndarray)
+    assert region.shape == (300, 400)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/converters/test_ome.py
+++ b/tests/integration/converters/test_ome.py
@@ -33,7 +33,7 @@ def test_ome(format_path):
     assert t.level_count == 3
     assert t.dimensions == (2220, 2967)
     assert t.level_dimensions == ((2220, 2967), (387, 463), (1280, 431))
-    assert t.level_downsamples == ()
+    assert t.level_downsamples == (1.0, 6.0723207259698295, 4.30918285962877)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/converters/test_ome_tiff.py
+++ b/tests/unit/converters/test_ome_tiff.py
@@ -17,10 +17,6 @@ class TestOMETiffReader:
         reader._tiff_series = [1, 2, 3, 4, 5]
         assert reader.level_count == 5
 
-    def test_ome_tiff_level_downsamples(self, mocker_tiff):
-        reader = OMETiffReader("")
-        assert reader.level_downsamples == ()
-
     def test_ome_tiff_level_image(self, mocker_tiff):
         reader = OMETiffReader("")
         tiff_array = np.array([[[0, 1], [2, 3]], [[4, 5], [6, 7]]])

--- a/tests/unit/converters/test_ome_zarr.py
+++ b/tests/unit/converters/test_ome_zarr.py
@@ -29,11 +29,6 @@ class TestOMEZarrReader:
         reader._zarray = zarr.array(data[1])
         assert reader.level_count == 3
 
-    def test_ome_zarr_level_downsamples(self, tmp_path, mocker_zarr):
-        zarr_path = os.path.join(tmp_path, "test.zarr")
-        reader = OMEZarrReader(zarr_path)
-        assert reader.level_downsamples == ()
-
     def test_ome_zarr_level_image(self, tmp_path, mocker_zarr, data):
         zarr_path = os.path.join(tmp_path, "test.zarr")
         reader = OMEZarrReader(zarr_path)

--- a/tests/unit/converters/test_openslide.py
+++ b/tests/unit/converters/test_openslide.py
@@ -16,19 +16,6 @@ class TestOpenSlideReader:
         reader._osd.level_count = 5
         assert reader.level_count == 5
 
-        # After substitution
-        reader._osd.level_count = 3
-        assert reader.level_count == 3
-
-    def test_osd_level_downsamples(self, mocker_osd):
-        reader = OpenSlideReader("")
-        reader._osd.level_downsamples = (5.6, 7.4, 6.7)
-        assert reader.level_downsamples == (5.6, 7.4, 6.7)
-
-        # After substitution
-        reader._osd.level_downsamples = (5.6, 7.4, 6.8)
-        assert reader.level_downsamples == (5.6, 7.4, 6.8)
-
     def test_level_image(self, mocker, mocker_osd):
         data_img = np.random.randint(
             low=0, high=256, size=128 * 128 * 3, dtype=np.uint8

--- a/tests/unit/test_openslide.py
+++ b/tests/unit/test_openslide.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 import tiledb
 
 from tests import check_level_info, get_CMU_1_SMALL_REGION_schemas
@@ -11,5 +12,9 @@ class TestLevelInfo:
         test_data_schemas = get_CMU_1_SMALL_REGION_schemas()
         tiledb.Array.create(os.path.join(tmp_path, "test.tdb"), test_data_schemas[0])
         with tiledb.open(os.path.join(tmp_path, "test.tdb"), "r") as A:
-            l0_info = LevelInfo.from_array(A, 0)
-            check_level_info(0, l0_info)
+            for level in range(42):
+                check_level_info(level, LevelInfo.from_array(A, level))
+
+            with pytest.raises(ValueError) as excinfo:
+                LevelInfo.from_array(A)
+            assert "Invalid level uri" in str(excinfo)

--- a/tiledbimg/converters/base.py
+++ b/tiledbimg/converters/base.py
@@ -13,11 +13,6 @@ class ImageReader(ABC):
     def level_count(self) -> int:
         """Return the number of levels for this multi-resolution image"""
 
-    @property
-    @abstractmethod
-    def level_downsamples(self) -> Sequence[float]:
-        """Return the scale factor for each level"""
-
     @abstractmethod
     def level_image(self, level: int) -> np.ndarray:
         """Return the image for the given level as (x, y, RGB) 3D numpy array"""
@@ -59,9 +54,6 @@ class ImageConverter(ABC):
         # Write metadata
         with tiledb.Group(output_group_path, "w") as G:
             G.meta["original_filename"] = input_path
-            level_downsamples = reader.level_downsamples
-            if level_downsamples:
-                G.meta["level_downsamples"] = level_downsamples
             for level_uri in uris:
                 G.add(os.path.basename(level_uri), relative=True)
 

--- a/tiledbimg/converters/ome_tiff.py
+++ b/tiledbimg/converters/ome_tiff.py
@@ -1,5 +1,3 @@
-from typing import Sequence
-
 import numpy as np
 import tifffile
 
@@ -13,11 +11,6 @@ class OMETiffReader(ImageReader):
     @property
     def level_count(self) -> int:
         return len(self._tiff_series)
-
-    @property
-    def level_downsamples(self) -> Sequence[float]:
-        # TODO
-        return ()
 
     def level_image(self, level: int) -> np.ndarray:
         return self._tiff_series[level].asarray().swapaxes(0, 2)

--- a/tiledbimg/converters/ome_zarr.py
+++ b/tiledbimg/converters/ome_zarr.py
@@ -1,5 +1,3 @@
-from typing import Sequence
-
 import numpy as np
 import zarr
 
@@ -13,11 +11,6 @@ class OMEZarrReader(ImageReader):
     @property
     def level_count(self) -> int:
         return len(self._zarray)
-
-    @property
-    def level_downsamples(self) -> Sequence[float]:
-        # TODO
-        return ()
 
     def level_image(self, level: int) -> np.ndarray:
         zarray_l0 = self._zarray[level][0]

--- a/tiledbimg/converters/openslide.py
+++ b/tiledbimg/converters/openslide.py
@@ -1,4 +1,4 @@
-from typing import Sequence, cast
+from typing import cast
 
 import numpy as np
 import openslide as osd
@@ -13,10 +13,6 @@ class OpenSlideReader(ImageReader):
     @property
     def level_count(self) -> int:
         return cast(int, self._osd.level_count)
-
-    @property
-    def level_downsamples(self) -> Sequence[float]:
-        return cast(Sequence[float], self._osd.level_downsamples)
 
     def level_image(self, level: int) -> np.ndarray:
         dims = self._osd.level_dimensions[level]


### PR DESCRIPTION
`level_downsamples` is [derived](https://github.com/openslide/openslide/blob/dd3a152250b460860614a3a793309245eebbcb7c/src/openslide.c#L285-L287) from `level_dimensions`, therefore it can be computed at runtime instead of being stored as metadata at ingestion time.