### PR TITLE
OMETiffReader fix: 'levels' should be TiffPageSeries, not TiffPage instances

### DIFF
--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -44,7 +44,7 @@ def test_ome_tiff_converter_different_dtypes(tmp_path):
     path = get_path("rand_uint16.ome.tiff")
     OMETiffConverter().convert_image(get_path(path), str(tmp_path))
 
-    assert len(tiledb.Group(str(tmp_path))) == 3
+    assert len(tiledb.Group(str(tmp_path))) == 4
     with tiledb.open(str(tmp_path / "l_0.tdb")) as A:
         assert A.schema.domain.dtype == np.uint32
         assert A.attr(0).dtype == np.uint16
@@ -54,6 +54,9 @@ def test_ome_tiff_converter_different_dtypes(tmp_path):
     with tiledb.open(str(tmp_path / "l_2.tdb")) as A:
         assert A.schema.domain.dtype == np.uint16
         assert A.attr(0).dtype == np.uint16
+    with tiledb.open(str(tmp_path / "l_3.tdb")) as A:
+        assert A.schema.domain.dtype == np.uint16
+        assert A.attr(0).dtype == np.uint8
 
 
 @pytest.mark.parametrize("max_workers", [0, 1, 2])

--- a/tiledbimg/converters/base.py
+++ b/tiledbimg/converters/base.py
@@ -68,9 +68,6 @@ class ImageConverter(ABC):
         for level in range(level_min, reader.level_count):
             uri = os.path.join(output_group_path, f"l_{level}.tdb")
             image = reader.level_image(level)
-            if len(image.shape) != len(self._dims):
-                # FIXME: temporary workaround until there is support for axes
-                continue
             level_metadata = reader.level_metadata(level)
             self._write_image(uri, image, level_metadata)
             uris.append(uri)
@@ -134,6 +131,7 @@ class ImageConverter(ABC):
     def _write_image(
         self, uri: str, image: np.ndarray, metadata: Dict[str, Any]
     ) -> None:
+        assert len(image.shape) == len(self._dims)
         # find the smallest dtype that can hold the number of image scalar values
         dim_dtype = np.min_scalar_type(image.size)
         dims = (


### PR DESCRIPTION
The `tifffile` package has several image-like classes that expose an `asarray()` method (`TiffPageSeries`, `TiffPage`, `TiffFrame`, etc.). On https://github.com/TileDB-Inc/TileDB-BioImaging/pull/20 `OMETiffReader._tiff_series` (`TiffPageSeries` instances) was replaced by `_pages` (`TiffPage` instances) but that turned out to be a mistake. We should serialize each image as a [level](https://github.com/cgohlke/tifffile/blob/a73812e98f58b068a590de862ed547820fd332ad/tests/test_tifffile.py#L16312), not [keyframe](https://github.com/cgohlke/tifffile/blob/a73812e98f58b068a590de862ed547820fd332ad/tests/test_tifffile.py#L16310); the latter is (apparently) needed only for the metadata of the image.
