### PR TITLE
Metadata tweaks

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -75,13 +75,6 @@ def get_CMU_1_SMALL_REGION_schemas(include_nested=False):
     ]
 
 
-def check_level_info(level, level_info):
-    assert level_info.level == level
-    assert tiledb.object_type(level_info.uri) == "array"
-    assert isinstance(level_info.dimensions, tuple)
-    assert all(isinstance(dim, int) for dim in level_info.dimensions)
-
-
 def get_path(uri: str) -> str:
     if uri.startswith("s3://"):
         s3 = boto3.client("s3")

--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -31,9 +31,7 @@ def test_ome_tiff_converter(tmp_path):
         4.30918285962877,
     )
     for i in range(t.level_count):
-        assert t.level_info[i] == LevelInfo(
-            uri="", level=i, dimensions=schemas[i].shape[:2]
-        )
+        assert t.level_info[i] == LevelInfo(uri="", dimensions=schemas[i].shape[:2])
     region = t.read_region(level=0, location=(100, 100), size=(300, 400))
     assert isinstance(region, np.ndarray)
     assert region.dtype == np.uint8

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -22,9 +22,7 @@ def test_ome_zarr_converter(tmp_path):
     assert t.level_dimensions == ((2220, 2967), (387, 463), (1280, 431))
     assert t.level_downsamples == (1.0, 6.0723207259698295, 4.30918285962877)
     for i in range(t.level_count):
-        assert t.level_info[i] == LevelInfo(
-            uri="", level=i, dimensions=schemas[i].shape[:2]
-        )
+        assert t.level_info[i] == LevelInfo(uri="", dimensions=schemas[i].shape[:2])
     region = t.read_region(level=0, location=(100, 100), size=(300, 400))
     assert isinstance(region, np.ndarray)
     assert region.dtype == np.uint8

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -26,9 +26,7 @@ def test_openslide_converter(tmp_path):
         assert os_img.get_best_level_for_downsample(factor) == best_level
         assert t.get_best_level_for_downsample(factor) == best_level
     for level, dimensions in enumerate(os_img.level_dimensions):
-        assert t.level_info[level] == LevelInfo(
-            uri="", level=level, dimensions=dimensions
-        )
+        assert t.level_info[level] == LevelInfo(uri="", dimensions=dimensions)
     region = t.read_region(level=0, location=(100, 100), size=(300, 400))
     assert isinstance(region, np.ndarray)
     assert region.dtype == np.uint8

--- a/tiledbimg/converters/base.py
+++ b/tiledbimg/converters/base.py
@@ -74,7 +74,6 @@ class ImageConverter(ABC):
 
         # Write group metadata
         with tiledb.Group(output_group_path, "w") as G:
-            G.meta["original_filename"] = input_path
             metadata = reader.metadata()
             if metadata:
                 G.meta.update(metadata)

--- a/tiledbimg/converters/base.py
+++ b/tiledbimg/converters/base.py
@@ -69,6 +69,7 @@ class ImageConverter(ABC):
             uri = os.path.join(output_group_path, f"l_{level}.tdb")
             image = reader.level_image(level)
             level_metadata = reader.level_metadata(level)
+            level_metadata["level"] = level
             self._write_image(uri, image, level_metadata)
             uris.append(uri)
 

--- a/tiledbimg/converters/ome_tiff.py
+++ b/tiledbimg/converters/ome_tiff.py
@@ -23,10 +23,20 @@ class OMETiffReader(ImageReader):
         return len(self._levels)
 
     def level_image(self, level: int) -> np.ndarray:
-        image = self._levels[level].asarray()
-        assert image.ndim == 3
-        # TODO: remove (hardcoded) swapaxes, need axes metadata
-        image = image.swapaxes(0, 2)
+        series = self._levels[level]
+        image = series.asarray()
+        # currently we support exactly 3 dimensions (X, Y, C), stored in this order
+        axes = series.axes.replace("S", "C")
+        if axes == "XYC":
+            pass
+        elif axes == "CYX":
+            image = np.swapaxes(image, 0, 2)
+        elif axes == "YXC":
+            image = np.swapaxes(image, 0, 1)
+        elif axes == "CXY":
+            image = np.moveaxis(image, 0, 2)
+        else:
+            raise NotImplementedError(f"Image axes {series.axes} not supported yet")
         return image
 
     def level_metadata(self, level: int) -> Dict[str, Any]:

--- a/tiledbimg/converters/ome_tiff.py
+++ b/tiledbimg/converters/ome_tiff.py
@@ -10,7 +10,8 @@ from .base import ImageConverter, ImageReader
 class OMETiffReader(ImageReader):
     def __init__(self, input_path: str):
         self._tiff = tifffile.TiffFile(input_path)
-        self._ome_metadata = tifffile.xml2dict(self._tiff.ome_metadata)
+        omexml = self._tiff.ome_metadata
+        self._ome_metadata = tifffile.xml2dict(omexml) if omexml else {}
         self._levels = []
         self._subifds = {}
         for series in self._tiff.series:


### PR DESCRIPTION
Misc. metadata fixes and improvements based on real-world TIFF files:
- Ignore missing OME-XML metadata
- Drop the `original_filename` metadata key; YAGNI
- Handle properly axes transformations (swapaxes, moveaxis) for any 3D image
  - A more general and elegant solution to this problem will be addressed in a separate PR.
- Store image level in metadata (instead of trying to infer it from the uri).