### PR TITLE
Change dimension order from XYC to CYX

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,8 +21,7 @@ def rgb_to_5d(pixels: np.ndarray) -> Sequence:
         channels = np.array([stack])
     elif len(pixels.shape) == 3:
         size_c = pixels.shape[2]
-        # Swapaxes for interchange x and y
-        channels = [np.array([pixels[:, :, c].swapaxes(0, 1)]) for c in range(size_c)]
+        channels = [np.array([pixels[:, :, c]]) for c in range(size_c)]
     else:
         assert False, f"expecting 2 or 3d: ({pixels.shape})"
     video = np.array([channels])
@@ -41,9 +40,9 @@ def get_CMU_1_SMALL_REGION_schemas(include_nested=False):
         tiledb.ArraySchema(
             domain=tiledb.Domain(
                 tiledb.Dim(
-                    name="X",
-                    domain=_domains[elem_id][0][:2],
-                    tile=_domains[elem_id][0][2],
+                    name="C",
+                    domain=_domains[elem_id][2][:2],
+                    tile=_domains[elem_id][2][2],
                     dtype=np.uint32,
                 ),
                 tiledb.Dim(
@@ -53,9 +52,9 @@ def get_CMU_1_SMALL_REGION_schemas(include_nested=False):
                     dtype=np.uint32,
                 ),
                 tiledb.Dim(
-                    name="C",
-                    domain=_domains[elem_id][2][:2],
-                    tile=_domains[elem_id][2][2],
+                    name="X",
+                    domain=_domains[elem_id][0][:2],
+                    tile=_domains[elem_id][0][2],
                     dtype=np.uint32,
                 ),
             ),

--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -2,6 +2,7 @@ import os
 import shutil
 
 import numpy as np
+import PIL.Image
 import pytest
 import tiledb
 
@@ -31,11 +32,14 @@ def test_ome_tiff_converter(tmp_path):
         4.30918285962877,
     )
     for i in range(t.level_count):
-        assert t.level_info[i] == LevelInfo(uri="", dimensions=schemas[i].shape[:2])
+        assert t.level_info[i] == LevelInfo(uri="", dimensions=schemas[i].shape[:-3:-1])
+
     region = t.read_region(level=0, location=(100, 100), size=(300, 400))
     assert isinstance(region, np.ndarray)
+    assert region.ndim == 3
     assert region.dtype == np.uint8
-    assert region.shape == (300, 400, 3)
+    img = PIL.Image.fromarray(region)
+    assert img.size == (300, 400)
 
 
 def test_ome_tiff_converter_different_dtypes(tmp_path):

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -1,4 +1,5 @@
 import numpy as np
+import PIL.Image
 import tiledb
 
 from tests import get_CMU_1_SMALL_REGION_schemas, get_path
@@ -22,8 +23,11 @@ def test_ome_zarr_converter(tmp_path):
     assert t.level_dimensions == ((2220, 2967), (387, 463), (1280, 431))
     assert t.level_downsamples == (1.0, 6.0723207259698295, 4.30918285962877)
     for i in range(t.level_count):
-        assert t.level_info[i] == LevelInfo(uri="", dimensions=schemas[i].shape[:2])
+        assert t.level_info[i] == LevelInfo(uri="", dimensions=schemas[i].shape[:-3:-1])
+
     region = t.read_region(level=0, location=(100, 100), size=(300, 400))
     assert isinstance(region, np.ndarray)
+    assert region.ndim == 3
     assert region.dtype == np.uint8
-    assert region.shape == (300, 400, 3)
+    img = PIL.Image.fromarray(region)
+    assert img.size == (300, 400)

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -1,5 +1,6 @@
 import numpy as np
-import openslide as osld
+import openslide
+import PIL.Image
 
 from tests import get_path
 from tiledbimg.converters.openslide import OpenSlideConverter
@@ -9,7 +10,7 @@ from tiledbimg.openslide import LevelInfo, TileDBOpenSlide
 def test_openslide_converter(tmp_path):
     svs_path = get_path("s3://tiledb-isaiah2/jjdemo/test4-convert/C3N-02572-22.svs")
 
-    os_img = osld.open_slide(svs_path)
+    os_img = openslide.open_slide(svs_path)
     assert os_img.level_count == 3
     assert os_img.dimensions == (19919, 21702)
     assert os_img.level_dimensions == ((19919, 21702), (4979, 5425), (2489, 2712))
@@ -27,7 +28,10 @@ def test_openslide_converter(tmp_path):
         assert t.get_best_level_for_downsample(factor) == best_level
     for level, dimensions in enumerate(os_img.level_dimensions):
         assert t.level_info[level] == LevelInfo(uri="", dimensions=dimensions)
+
     region = t.read_region(level=0, location=(100, 100), size=(300, 400))
     assert isinstance(region, np.ndarray)
+    assert region.ndim == 3
     assert region.dtype == np.uint8
-    assert region.shape == (300, 400, 3)
+    img = PIL.Image.fromarray(region)
+    assert img.size == (300, 400)

--- a/tests/unit/converters/test_ome_zarr.py
+++ b/tests/unit/converters/test_ome_zarr.py
@@ -32,7 +32,7 @@ class TestOMEZarrReader:
     def test_ome_zarr_level_image(self, tmp_path, mocker_zarr, data):
         zarr_path = os.path.join(tmp_path, "test.zarr")
         reader = OMEZarrReader(zarr_path)
-        expected = data[0]
+        expected = np.moveaxis(data[0], 2, 0)
         zarr_array = zarr.array(data[1])
         # zarr_array.shape (level_count, 3, 1, 256, 256) = (t, c, z, y, x)
         reader._zarray.__getitem__.return_value = zarr_array

--- a/tests/unit/converters/test_openslide.py
+++ b/tests/unit/converters/test_openslide.py
@@ -22,7 +22,7 @@ class TestOpenSlideReader:
         )
         data_img = data_img.reshape(128, 128, 3)
         img = Image.fromarray(data_img, "RGB")
-        expected = np.asarray(img).swapaxes(0, 1)
+        expected = np.moveaxis(np.asarray(img), 2, 0)
         reader = OpenSlideReader("")
         reader._osd.read_region.return_value = img
         np.testing.assert_array_almost_equal(reader.level_image(0), expected)

--- a/tiledbimg/converters/base.py
+++ b/tiledbimg/converters/base.py
@@ -43,11 +43,11 @@ class Dimension:
 class ImageConverter(ABC):
     def __init__(
         self,
-        x_dim: Dimension = Dimension("X", 1024),
-        y_dim: Dimension = Dimension("Y", 1024),
-        c_dim: Dimension = Dimension("C", 3),
+        c_dim: Dimension = Dimension("C", 3),  # channel
+        y_dim: Dimension = Dimension("Y", 1024),  # height
+        x_dim: Dimension = Dimension("X", 1024),  # width
     ):
-        self._dims = (x_dim, y_dim, c_dim)
+        self._dims = (c_dim, y_dim, x_dim)
 
     def convert_image(
         self, input_path: str, output_group_path: str, level_min: int = 0

--- a/tiledbimg/converters/ome_tiff.py
+++ b/tiledbimg/converters/ome_tiff.py
@@ -25,16 +25,16 @@ class OMETiffReader(ImageReader):
     def level_image(self, level: int) -> np.ndarray:
         series = self._levels[level]
         image = series.asarray()
-        # currently we support exactly 3 dimensions (X, Y, C), stored in this order
+        # currently we support exactly 3 dimensions (C, Y, X), stored in this order
         axes = series.axes.replace("S", "C")
         if axes == "XYC":
-            pass
-        elif axes == "CYX":
             image = np.swapaxes(image, 0, 2)
+        elif axes == "CYX":
+            pass
         elif axes == "YXC":
-            image = np.swapaxes(image, 0, 1)
+            image = np.moveaxis(image, 2, 0)
         elif axes == "CXY":
-            image = np.moveaxis(image, 0, 2)
+            image = np.swapaxes(image, 1, 2)
         else:
             raise NotImplementedError(f"Image axes {series.axes} not supported yet")
         return image

--- a/tiledbimg/converters/ome_zarr.py
+++ b/tiledbimg/converters/ome_zarr.py
@@ -14,9 +14,7 @@ class OMEZarrReader(ImageReader):
 
     def level_image(self, level: int) -> np.ndarray:
         zarray_l0 = self._zarray[level][0]
-        zyx_shape = tuple(zarray_l0.shape[i] for i in (1, 3, 4))
-        reshaped = np.asarray(zarray_l0).reshape(zyx_shape)
-        return reshaped.swapaxes(0, 2)
+        return np.asarray(zarray_l0).squeeze()
 
 
 class OMEZarrConverter(ImageConverter):

--- a/tiledbimg/converters/openslide.py
+++ b/tiledbimg/converters/openslide.py
@@ -16,8 +16,13 @@ class OpenSlideReader(ImageReader):
 
     def level_image(self, level: int) -> np.ndarray:
         dims = self._osd.level_dimensions[level]
+        # image is in (width, height, channel) == XYC
         image = self._osd.read_region((0, 0), level, dims).convert("RGB")
-        return np.asarray(image).swapaxes(0, 1)
+        # np.asarray() transposes it to (height, width, channel) == YXC
+        # https://stackoverflow.com/questions/49084846/why-different-size-when-converting-pil-image-to-numpy-array
+        data = np.asarray(image)
+        # we want (channel, height, width) so move channel first
+        return np.moveaxis(data, 2, 0)
 
 
 class OpenSlideConverter(ImageConverter):


### PR DESCRIPTION
First PR towards supporting any NGFF compatible 2 to 5 dimensional image data; more to follow.

This PR still supports only 3D images but changes the order of dimensions from the current `XYC` (width, height, channel) to `CYX`. This is the canonical dimension order of multichannel images (the full canonical order for 5D data is `TCZYX`).

Additionally, `TileDBOpenSlide.read_region` changed to return a 3D numpy array in `YXC` order instead of `XYC` in order to be consistent with the Numpy ([as opposed to PIL](https://stackoverflow.com/questions/57259519/handling-height-width-vs-width-height-coordinate-order-in-pil-vs-ndarray)) convention.

**Note**: backwards incompatible change.