### PR TITLE
Support general axes transpositions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,6 @@ repos:
     hooks:
     - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v0.982
     hooks:
       - id: mypy

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "local_scheme": "dirty-tag",
         "write_to": "tiledbimg/version.py",
     },
-    install_requires=["tiledb"],
+    install_requires=["levenshtein", "tiledb"],
     extras_require={
         "zarr": zarr,
         "openslide": openslide,

--- a/tests/unit/test_axes.py
+++ b/tests/unit/test_axes.py
@@ -1,0 +1,167 @@
+import itertools as it
+
+import numpy as np
+import pytest
+
+from tiledbimg.converters.axes import Axes, Move, Swap, minimize_transpositions
+
+
+class TestTranspositions:
+    @pytest.mark.parametrize(
+        "s,i,j", [("ADCBE", 1, 3), ("DBCAE", 3, 0), ("ACBDE", 2, 1)]
+    )
+    def test_swap(self, s, i, j):
+        swap = Swap(i, j)
+        assert swap.transposed(s) == list("ABCDE")
+        b = list(s)
+        assert swap.transpose(b) is None
+        assert b == list("ABCDE")
+
+    @pytest.mark.parametrize(
+        "s,i,j",
+        [
+            ("ADBCE", 1, 3),
+            ("ACDBE", 3, 1),
+            ("ACBDE", 1, 2),
+            ("ACBDE", 2, 1),
+            ("EABCD", 0, 4),
+            ("BCDEA", 4, 0),
+        ],
+    )
+    def test_move(self, s, i, j):
+        move = Move(i, j)
+        assert move.transposed(s) == list("ABCDE")
+        b = list(s)
+        assert move.transpose(b) is None
+        assert b == list("ABCDE")
+
+    @pytest.mark.parametrize(
+        "s,t,transpositions",
+        [
+            ("EABCD", "ABCDE", [Move(0, 4)]),
+            ("EADCB", "ABCDE", [Move(0, 4), Swap(1, 3)]),
+            ("ECABD", "ABCDE", [Move(0, 4), Move(0, 2)]),
+            ("AFDEBGC", "ABCDEFG", [Swap(1, 4), Move(6, 2)]),
+        ],
+    )
+    def test_minimize_transpositions(self, s, t, transpositions):
+        assert minimize_transpositions(s, t) == transpositions
+        s = list(s)
+        for transposition in transpositions:
+            transposition.transpose(s)
+        assert s == list(t)
+
+
+class TestAxes:
+    def test_init(self):
+        assert Axes("XYZ").members == "XYZ"
+
+        with pytest.raises(ValueError) as excinfo:
+            Axes("XYZW")
+        assert str(excinfo.value) == "'W' is not a valid Axis"
+
+        with pytest.raises(ValueError) as excinfo:
+            Axes("XYZX")
+        assert "Duplicate axes" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "canonical_axes", ["YX", "ZYX", "CYX", "TYX", "CZYX", "TCYX", "TZYX", "TCZYX"]
+    )
+    def test_canonical(self, canonical_axes):
+        for axes in map(Axes, it.permutations(canonical_axes)):
+            assert axes.canonical().members == canonical_axes
+
+    def test_transpose_2d(self):
+        a = np.random.rand(60, 40)
+        assert_transpose("YX", a, a)
+        assert_transpose("XY", a, np.swapaxes(a, 0, 1))
+
+    def test_transpose_3d(self):
+        a = np.random.rand(10, 60, 40)
+        for s in "ZYX", "CYX", "TYX":
+            assert_transpose(s, a, a)
+        for s in "XYZ", "XYC", "XYT":
+            assert_transpose(s, a, np.swapaxes(a, 0, 2))
+        for s in "ZXY", "CXY", "TXY":
+            assert_transpose(s, a, np.swapaxes(a, 1, 2))
+        for s in "YXZ", "YXC", "YXT":
+            assert_transpose(s, a, np.moveaxis(a, 2, 0))
+
+    def test_transpose_4d(self):
+        a = np.random.rand(3, 10, 60, 40)
+        for s in "CZYX", "TCYX", "TZYX":
+            assert_transpose(s, a, a)
+        for s in "ZCYX", "CTYX", "ZTYX":
+            assert_transpose(s, a, np.swapaxes(a, 0, 1))
+        for s in "CZXY", "TCXY", "TZXY":
+            assert_transpose(s, a, np.swapaxes(a, 2, 3))
+        for s in "ZYXC", "CYXT", "ZYXT":
+            assert_transpose(s, a, np.moveaxis(a, 3, 0))
+        for s in "CYXZ", "TYXC", "TYXZ":
+            assert_transpose(s, a, np.moveaxis(a, 3, 1))
+        for s in "YXZC", "YXCT", "YXZT":
+            assert_transpose(s, a, np.moveaxis(np.moveaxis(a, 2, 0), 3, 0))
+        for s in "YXCZ", "YXTC", "YXTZ":
+            assert_transpose(s, a, np.moveaxis(np.moveaxis(a, 2, 0), 3, 1))
+        for s in "ZCXY", "CTXY", "ZTXY":
+            assert_transpose(s, a, np.swapaxes(np.swapaxes(a, 0, 1), 2, 3))
+        for s in "XYZC", "XYCT", "XYZT":
+            assert_transpose(s, a, np.swapaxes(np.swapaxes(a, 0, 3), 1, 2))
+        for s in "CXYZ", "TXYC", "TXYZ":
+            assert_transpose(s, a, np.swapaxes(np.moveaxis(a, 3, 1), 2, 3))
+        for s in "ZXYC", "CXYT", "ZXYT":
+            assert_transpose(s, a, np.swapaxes(np.moveaxis(a, 3, 0), 2, 3))
+        for s in "XYCZ", "XYTC", "XYTZ":
+            assert_transpose(s, a, np.swapaxes(np.moveaxis(a, 2, 0), 1, 3))
+
+    def test_transpose_5d(self):
+        a = np.random.rand(7, 3, 10, 60, 40)
+        assert_transpose("TCZYX", a, a)
+
+        assert_transpose("CTZYX", a, np.swapaxes(a, 0, 1))
+        assert_transpose("ZCTYX", a, np.swapaxes(a, 0, 2))
+        assert_transpose("TZCYX", a, np.swapaxes(a, 1, 2))
+        assert_transpose("TCXYZ", a, np.swapaxes(a, 2, 4))
+        assert_transpose("TCZXY", a, np.swapaxes(a, 3, 4))
+
+        assert_transpose("ZTCYX", a, np.moveaxis(a, 0, 2))
+        assert_transpose("CZTYX", a, np.moveaxis(a, 2, 0))
+        assert_transpose("CZYXT", a, np.moveaxis(a, 4, 0))
+        assert_transpose("TZYXC", a, np.moveaxis(a, 4, 1))
+        assert_transpose("TCYXZ", a, np.moveaxis(a, 4, 2))
+
+        assert_transpose("CTXYZ", a, np.swapaxes(np.swapaxes(a, 0, 1), 2, 4))
+        assert_transpose("CTZXY", a, np.swapaxes(np.swapaxes(a, 0, 1), 3, 4))
+        assert_transpose("ZCTXY", a, np.swapaxes(np.swapaxes(a, 0, 2), 3, 4))
+        assert_transpose("YXZTC", a, np.swapaxes(np.swapaxes(a, 0, 3), 1, 4))
+        assert_transpose("XYZCT", a, np.swapaxes(np.swapaxes(a, 0, 4), 1, 3))
+        assert_transpose("ZCXYT", a, np.swapaxes(np.swapaxes(a, 0, 4), 2, 4))
+        assert_transpose("TZCXY", a, np.swapaxes(np.swapaxes(a, 1, 2), 3, 4))
+        assert_transpose("TZXYC", a, np.swapaxes(np.swapaxes(a, 1, 4), 2, 4))
+
+        assert_transpose("ZTXYC", a, np.swapaxes(np.moveaxis(a, 0, 2), 1, 4))
+        assert_transpose("ZTCXY", a, np.swapaxes(np.moveaxis(a, 0, 2), 3, 4))
+        assert_transpose("YXCZT", a, np.swapaxes(np.moveaxis(a, 0, 3), 0, 4))
+        assert_transpose("XYCZT", a, np.swapaxes(np.moveaxis(a, 1, 3), 0, 4))
+        assert_transpose("CZTXY", a, np.swapaxes(np.moveaxis(a, 2, 0), 3, 4))
+        assert_transpose("CXYTZ", a, np.swapaxes(np.moveaxis(a, 3, 0), 2, 4))
+        assert_transpose("CXYZT", a, np.swapaxes(np.moveaxis(a, 4, 0), 2, 4))
+        assert_transpose("CZXYT", a, np.swapaxes(np.moveaxis(a, 4, 0), 3, 4))
+        assert_transpose("ZTYXC", a, np.swapaxes(np.moveaxis(a, 4, 1), 0, 2))
+        assert_transpose("TXYZC", a, np.swapaxes(np.moveaxis(a, 4, 1), 2, 4))
+        assert_transpose("CTYXZ", a, np.swapaxes(np.moveaxis(a, 4, 2), 0, 1))
+        assert_transpose("TXYCZ", a, np.swapaxes(np.moveaxis(a, 4, 2), 1, 4))
+
+        assert_transpose("XYTCZ", a, np.moveaxis(np.moveaxis(a, 0, 4), 0, 3))
+        assert_transpose("YXTCZ", a, np.moveaxis(np.moveaxis(a, 0, 4), 0, 4))
+        assert_transpose("TYXCZ", a, np.moveaxis(np.moveaxis(a, 1, 4), 1, 4))
+        assert_transpose("ZYXTC", a, np.moveaxis(np.moveaxis(a, 3, 0), 4, 1))
+        assert_transpose("CYXTZ", a, np.moveaxis(np.moveaxis(a, 3, 0), 4, 2))
+        assert_transpose("TYXZC", a, np.moveaxis(np.moveaxis(a, 4, 1), 4, 2))
+        assert_transpose("ZCYXT", a, np.moveaxis(np.moveaxis(a, 4, 0), 1, 2))
+        assert_transpose("ZYXCT", a, np.moveaxis(np.moveaxis(a, 4, 0), 4, 1))
+        assert_transpose("CYXZT", a, np.moveaxis(np.moveaxis(a, 4, 0), 4, 2))
+
+
+def assert_transpose(s, a, b):
+    np.testing.assert_array_equal(Axes(s).transpose(a), b)

--- a/tiledbimg/converters/axes.py
+++ b/tiledbimg/converters/axes.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections import Counter
+from dataclasses import dataclass
+from operator import itemgetter
+from typing import Iterator, List, MutableSequence, Sequence, TypeVar
+
+import Levenshtein
+import numpy as np
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class Transpose(ABC):
+    i: int
+    j: int
+
+    def transposed(self, s: Sequence[T]) -> List[T]:
+        """Return the transposed version of the given sequence"""
+        s = list(s)
+        self.transpose(s)
+        return s
+
+    @abstractmethod
+    def transpose(self, s: MutableSequence[T]) -> None:
+        """Transpose the given mutable sequence in place"""
+
+    @abstractmethod
+    def transposed_array(self, a: np.ndarray) -> np.ndarray:
+        """Return the transposed version of the given numpy array"""
+
+
+class Swap(Transpose):
+    def transpose(self, s: MutableSequence[T]) -> None:
+        i, j = self.i, self.j
+        s[i], s[j] = s[j], s[i]
+
+    def transposed_array(self, a: np.ndarray) -> np.ndarray:
+        return np.swapaxes(a, self.i, self.j)
+
+
+class Move(Transpose):
+    def transpose(self, s: MutableSequence[T]) -> None:
+        s.insert(self.j, s.pop(self.i))
+
+    def transposed_array(self, a: np.ndarray) -> np.ndarray:
+        return np.moveaxis(a, self.i, self.j)
+
+
+def minimize_transpositions(s: Sequence[T], t: Sequence[T]) -> Sequence[Transpose]:
+    assert Counter(s) == Counter(t)
+    n = len(s)
+    s = list(s)
+    t = list(t)
+    transpositions = []
+    while s != t:
+        weighted_transpositions = (
+            (Levenshtein.distance(transposition.transposed(s), t), transposition)
+            for transposition in gen_transpositions(n)
+        )
+        best_transposition = min(weighted_transpositions, key=itemgetter(0))[1]
+        best_transposition.transpose(s)
+        transpositions.append(best_transposition)
+    return transpositions
+
+
+def gen_transpositions(n: int) -> Iterator[Transpose]:
+    for i in range(n):
+        for j in range(i + 1, n):
+            yield Swap(i, j)
+            yield Move(i, j)
+            yield Move(j, i)
+
+
+class Axes:
+    _CANONICAL_MEMBERS = "TCZYX"
+
+    def __init__(self, members: str) -> None:
+        axes = set(members)
+        if len(members) != len(axes):
+            raise ValueError(f"Duplicate axes: {members}")
+        axes.difference_update(self._CANONICAL_MEMBERS)
+        if axes:
+            raise ValueError(f"{axes.pop()!r} is not a valid Axis")
+        self.members = members
+
+    def canonical(self) -> Axes:
+        """Return an Axes instance with the same axis members as this one in canonical order"""
+        return Axes("".join(m for m in self._CANONICAL_MEMBERS if m in self.members))
+
+    def transpose(self, a: np.ndarray) -> np.ndarray:
+        """Transpose the given array to the canonical axes order"""
+        for t in minimize_transpositions(self.members, self.canonical().members):
+            a = t.transposed_array(a)
+        return a

--- a/tiledbimg/converters/ome_tiff.py
+++ b/tiledbimg/converters/ome_tiff.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 import numpy as np
 import tifffile
 
-from .base import ImageConverter, ImageReader, ImageWriter
+from .base import Axes, ImageConverter, ImageReader, ImageWriter
 
 
 class OMETiffReader(ImageReader):
@@ -19,22 +19,11 @@ class OMETiffReader(ImageReader):
     def level_count(self) -> int:
         return len(self._levels)
 
+    def level_axes(self, level: int) -> Axes:
+        return Axes(self._levels[level].axes.replace("S", "C"))
+
     def level_image(self, level: int) -> np.ndarray:
-        series = self._levels[level]
-        image = series.asarray()
-        # currently we support exactly 3 dimensions (C, Y, X), stored in this order
-        axes = series.axes.replace("S", "C")
-        if axes == "XYC":
-            image = np.swapaxes(image, 0, 2)
-        elif axes == "CYX":
-            pass
-        elif axes == "YXC":
-            image = np.moveaxis(image, 2, 0)
-        elif axes == "CXY":
-            image = np.swapaxes(image, 1, 2)
-        else:
-            raise NotImplementedError(f"Image axes {series.axes} not supported yet")
-        return image
+        return self._levels[level].asarray()
 
     def level_metadata(self, level: int) -> Dict[str, Any]:
         series = self._levels[level]

--- a/tiledbimg/converters/ome_zarr.py
+++ b/tiledbimg/converters/ome_zarr.py
@@ -11,7 +11,7 @@ from numcodecs import Blosc
 from ome_zarr.reader import Reader, ZarrLocation
 from ome_zarr.writer import write_multiscale
 
-from .base import ImageConverter, ImageReader, ImageWriter
+from .base import Axes, ImageConverter, ImageReader, ImageWriter
 
 
 class OMEZarrWriter(ImageWriter):
@@ -94,9 +94,17 @@ class OMEZarrReader(ImageReader):
     def level_count(self) -> int:
         return len(self.nodes)
 
+    def level_axes(self, level: int) -> Axes:
+        return Axes("CYX")
+
     def level_image(self, level: int) -> np.ndarray:
         data = self.nodes[level].data
         assert len(data) == 1
+        leveled_zarray = data[0]
+        if leveled_zarray.shape[0] != 1:
+            raise NotImplementedError("T axes not supported yet")
+        if leveled_zarray.shape[2] != 1:
+            raise NotImplementedError("Z axes not supported yet")
         # From NGFF format spec there is guarantee that axes are t,c,z,y,x
         return np.asarray(data[0]).squeeze()
 

--- a/tiledbimg/converters/openslide.py
+++ b/tiledbimg/converters/openslide.py
@@ -3,7 +3,7 @@ from typing import cast
 import numpy as np
 import openslide as osd
 
-from .base import ImageConverter, ImageReader, ImageWriter
+from .base import Axes, ImageConverter, ImageReader, ImageWriter
 
 
 class OpenSlideReader(ImageReader):
@@ -14,15 +14,16 @@ class OpenSlideReader(ImageReader):
     def level_count(self) -> int:
         return cast(int, self._osd.level_count)
 
+    def level_axes(self, level: int) -> Axes:
+        return Axes("YXC")
+
     def level_image(self, level: int) -> np.ndarray:
         dims = self._osd.level_dimensions[level]
         # image is in (width, height, channel) == XYC
         image = self._osd.read_region((0, 0), level, dims).convert("RGB")
         # np.asarray() transposes it to (height, width, channel) == YXC
         # https://stackoverflow.com/questions/49084846/why-different-size-when-converting-pil-image-to-numpy-array
-        data = np.asarray(image)
-        # we want (channel, height, width) so move channel first
-        return np.moveaxis(data, 2, 0)
+        return np.asarray(image)
 
 
 class OpenSlideConverter(ImageConverter):


### PR DESCRIPTION
Second PR towards supporting any NGFF compatible 2 to 5 dimensional image data; follow-up to https://github.com/TileDB-Inc/TileDB-BioImaging/pull/26.

This PR:
- Moves the swap/move axes logic (currently hardcoded in the various converters) to a new `tiledbimg.converters.axes` module
- Generalizes this logic to support transforming from an arbitrary axes sequence to a canonical axes sequence. Ideally the transformation uses the minimal number of transpositions, although this is unproven; the current algorithm just picks greedily the transposition that minimizes the [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) between the input and the target sequence.