### PR TITLE
Drop ImageReader.convert_images

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import os
 import urllib.parse
+from pathlib import Path
 
 import boto3
 import numpy as np
@@ -10,7 +11,7 @@ if os.name == "posix":
     multiprocessing.set_start_method("forkserver")
 
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+DATA_DIR = Path(__file__).parent / "data"
 
 
 def get_schema(x_size, y_size):
@@ -29,13 +30,13 @@ def get_schema(x_size, y_size):
     )
 
 
-def get_path(uri: str) -> str:
+def get_path(uri):
     if uri.startswith("s3://"):
         s3 = boto3.client("s3")
         parsed_uri = urllib.parse.urlparse(uri)
-        local_path = os.path.join(DATA_DIR, os.path.basename(parsed_uri.path))
-        if not os.path.exists(local_path):
+        local_path = DATA_DIR / Path(parsed_uri.path).name
+        if not local_path.exists():
             s3.download_file(parsed_uri.netloc, parsed_uri.path.lstrip("/"), local_path)
     else:
-        local_path = os.path.join(DATA_DIR, uri)
+        local_path = DATA_DIR / uri
     return local_path

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import numpy as np
 import PIL.Image
@@ -16,7 +15,7 @@ schemas = (get_schema(2220, 2967), get_schema(387, 463), get_schema(1280, 431))
 
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
 def test_ome_zarr_converter(tmp_path, series_idx):
-    input_path = Path(get_path("CMU-1-Small-Region.ome.zarr")) / str(series_idx)
+    input_path = get_path("CMU-1-Small-Region.ome.zarr") / str(series_idx)
     OMEZarrConverter().to_tiledb(input_path, str(tmp_path))
 
     # check the first (highest) resolution layer only
@@ -40,29 +39,9 @@ def test_ome_zarr_converter(tmp_path, series_idx):
     )
 
 
-def test_ome_zarr_converter_images(tmp_path):
-    OMEZarrConverter().convert_images(
-        Path(get_path("CMU-1-Small-Region.ome.zarr")).glob("[012]"),
-        tmp_path,
-        level_min=0,
-        max_workers=0,
-    )
-    for image_uri in tmp_path.glob("*"):
-        img_idx = int(image_uri.name)
-        t = TileDBOpenSlide.from_group_uri(str(image_uri))
-        assert t.dimensions == t.level_dimensions[0] == schemas[img_idx].shape[:-3:-1]
-
-        region = t.read_region(level=0, location=(100, 100), size=(100, 200))
-        assert isinstance(region, np.ndarray)
-        assert region.ndim == 3
-        assert region.dtype == np.uint8
-        img = PIL.Image.fromarray(region)
-        assert img.size == (100, 200)
-
-
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
 def test_tiledb_to_ome_zarr_rountrip(tmp_path, series_idx):
-    input_zarr_path = Path(get_path("CMU-1-Small-Region.ome.zarr")) / str(series_idx)
+    input_zarr_path = get_path("CMU-1-Small-Region.ome.zarr") / str(series_idx)
     tiledb_path = tmp_path / "to_tiledb"
     output_zarr_path = tmp_path / "from_tiledb"
 

--- a/tiledbimg/converters/ome_tiff.py
+++ b/tiledbimg/converters/ome_tiff.py
@@ -15,6 +15,9 @@ class OMETiffReader(ImageReader):
         # XXX ignore all but the first series
         self._levels = self._tiff.series[0].levels
 
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self._tiff.close()
+
     @property
     def level_count(self) -> int:
         return len(self._levels)
@@ -55,7 +58,8 @@ class OMETiffReader(ImageReader):
         )
         return {"pickled_write_kwargs": pickle.dumps(write_kwargs)}
 
-    def metadata(self) -> Dict[str, Any]:
+    @property
+    def group_metadata(self) -> Dict[str, Any]:
         writer_kwargs = dict(
             bigtiff=self._tiff.is_bigtiff,
             byteorder=self._tiff.byteorder,
@@ -72,5 +76,5 @@ class OMETiffConverter(ImageConverter):
     def _get_image_reader(self, input_path: str) -> ImageReader:
         return OMETiffReader(input_path)
 
-    def _get_image_writer(self, input_path: str, output_path: str) -> ImageWriter:
-        pass
+    def _get_image_writer(self, output_path: str) -> ImageWriter:
+        raise NotImplementedError

--- a/tiledbimg/converters/openslide.py
+++ b/tiledbimg/converters/openslide.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Any, Dict, cast
 
 import numpy as np
 import openslide as osd
@@ -9,6 +9,9 @@ from .base import Axes, ImageConverter, ImageReader, ImageWriter
 class OpenSlideReader(ImageReader):
     def __init__(self, input_path: str):
         self._osd = osd.OpenSlide(input_path)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self._osd.close()
 
     @property
     def level_count(self) -> int:
@@ -25,6 +28,13 @@ class OpenSlideReader(ImageReader):
         # https://stackoverflow.com/questions/49084846/why-different-size-when-converting-pil-image-to-numpy-array
         return np.asarray(image)
 
+    def level_metadata(self, level: int) -> Dict[str, Any]:
+        return {}
+
+    @property
+    def group_metadata(self) -> Dict[str, Any]:
+        return {}
+
 
 class OpenSlideConverter(ImageConverter):
     """Converter of OpenSlide-supported images to TileDB Groups of Arrays"""
@@ -32,5 +42,5 @@ class OpenSlideConverter(ImageConverter):
     def _get_image_reader(self, input_path: str) -> ImageReader:
         return OpenSlideReader(input_path)
 
-    def _get_image_writer(self, input_path: str, output_path: str) -> ImageWriter:
-        pass
+    def _get_image_writer(self, output_path: str) -> ImageWriter:
+        raise NotImplementedError


### PR DESCRIPTION
It's not the responsibility of the library to parallelize a given function (or functions); this can (and should) be done by the library user if desired.