### PR TITLE
Refactor ImageWriter/ImageConverter.from_tiledb

### DIFF
--- a/tiledbimg/converters/base.py
+++ b/tiledbimg/converters/base.py
@@ -32,6 +32,10 @@ class ImageReader(ABC):
         """Return the number of levels for this multi-resolution image"""
 
     @abstractmethod
+    def level_axes(self, level: int) -> Axes:
+        """Return the axes for the given level."""
+
+    @abstractmethod
     def level_image(self, level: int) -> np.ndarray:
         """
         Return the image for the given level as numpy array.
@@ -40,16 +44,12 @@ class ImageReader(ABC):
         """
 
     @abstractmethod
-    def level_axes(self, level: int) -> Axes:
-        """Return the axes for the given level."""
-
     def level_metadata(self, level: int) -> Dict[str, Any]:
         """Return the metadata for the given level."""
-        return {}
 
+    @abstractmethod
     def metadata(self) -> Dict[str, Any]:
         """Return the metadata for the whole multi-resolution image."""
-        return {}
 
 
 class ImageWriter(ABC):
@@ -57,13 +57,13 @@ class ImageWriter(ABC):
     def level_image(self, array: tiledb.Array) -> np.ndarray:
         """Return the image from the given TileDB array as numpy array."""
 
+    @abstractmethod
     def level_metadata(self, array: tiledb.Array) -> Dict[str, Any]:
         """Return the metadata from the given TileDB array."""
-        return {}
 
+    @abstractmethod
     def metadata(self, group: tiledb.Group) -> Dict[str, Any]:
         """Return the metadata from the given TileDB group."""
-        return {}
 
     @abstractmethod
     def write(

--- a/tiledbimg/converters/ome_tiff.py
+++ b/tiledbimg/converters/ome_tiff.py
@@ -15,6 +15,9 @@ class OMETiffReader(ImageReader):
         # XXX ignore all but the first series
         self._levels = self._tiff.series[0].levels
 
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self._tiff.close()
+
     @property
     def level_count(self) -> int:
         return len(self._levels)

--- a/tiledbimg/converters/ome_tiff.py
+++ b/tiledbimg/converters/ome_tiff.py
@@ -55,7 +55,8 @@ class OMETiffReader(ImageReader):
         )
         return {"pickled_write_kwargs": pickle.dumps(write_kwargs)}
 
-    def metadata(self) -> Dict[str, Any]:
+    @property
+    def group_metadata(self) -> Dict[str, Any]:
         writer_kwargs = dict(
             bigtiff=self._tiff.is_bigtiff,
             byteorder=self._tiff.byteorder,

--- a/tiledbimg/converters/ome_tiff.py
+++ b/tiledbimg/converters/ome_tiff.py
@@ -72,5 +72,5 @@ class OMETiffConverter(ImageConverter):
     def _get_image_reader(self, input_path: str) -> ImageReader:
         return OMETiffReader(input_path)
 
-    def _get_image_writer(self, input_path: str, output_path: str) -> ImageWriter:
-        pass
+    def _get_image_writer(self, output_path: str) -> ImageWriter:
+        raise NotImplementedError

--- a/tiledbimg/converters/ome_zarr.py
+++ b/tiledbimg/converters/ome_zarr.py
@@ -46,12 +46,11 @@ class OMEZarrReader(ImageReader):
     @property
     def group_metadata(self) -> Dict[str, Any]:
         multiscale = self._multiscale
-        coordinate_transformations = (
-            d.get("coordinateTransformations") for d in multiscale["datasets"]
-        )
         writer_kwargs = dict(
             axes=multiscale.get("axes"),
-            coordinate_transformations=list(filter(None, coordinate_transformations)),
+            coordinate_transformations=[
+                d.get("coordinateTransformations") for d in multiscale["datasets"]
+            ],
             name=multiscale.get("name"),
             metadata=multiscale.get("metadata"),
             omero=self.root_attrs.get("omero"),

--- a/tiledbimg/converters/openslide.py
+++ b/tiledbimg/converters/openslide.py
@@ -32,5 +32,5 @@ class OpenSlideConverter(ImageConverter):
     def _get_image_reader(self, input_path: str) -> ImageReader:
         return OpenSlideReader(input_path)
 
-    def _get_image_writer(self, input_path: str, output_path: str) -> ImageWriter:
-        pass
+    def _get_image_writer(self, output_path: str) -> ImageWriter:
+        raise NotImplementedError

--- a/tiledbimg/converters/openslide.py
+++ b/tiledbimg/converters/openslide.py
@@ -10,6 +10,9 @@ class OpenSlideReader(ImageReader):
     def __init__(self, input_path: str):
         self._osd = osd.OpenSlide(input_path)
 
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self._osd.close()
+
     @property
     def level_count(self) -> int:
         return cast(int, self._osd.level_count)

--- a/tiledbimg/converters/openslide.py
+++ b/tiledbimg/converters/openslide.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Any, Dict, cast
 
 import numpy as np
 import openslide as osd
@@ -24,6 +24,12 @@ class OpenSlideReader(ImageReader):
         # np.asarray() transposes it to (height, width, channel) == YXC
         # https://stackoverflow.com/questions/49084846/why-different-size-when-converting-pil-image-to-numpy-array
         return np.asarray(image)
+
+    def level_metadata(self, level: int) -> Dict[str, Any]:
+        return {}
+
+    def metadata(self) -> Dict[str, Any]:
+        return {}
 
 
 class OpenSlideConverter(ImageConverter):

--- a/tiledbimg/converters/openslide.py
+++ b/tiledbimg/converters/openslide.py
@@ -28,7 +28,8 @@ class OpenSlideReader(ImageReader):
     def level_metadata(self, level: int) -> Dict[str, Any]:
         return {}
 
-    def metadata(self) -> Dict[str, Any]:
+    @property
+    def group_metadata(self) -> Dict[str, Any]:
         return {}
 
 


### PR DESCRIPTION
- Refactor `ImageWriter` and `ImageConverter.from_tiledb` (and at a lesser degree `ImageReader` and `ImageConverter.to_tiledb`).
- Change the OME-Zarr stored metadata from pickle to json.  