### PR TITLE
Hotfix PYPI publish repository tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Build package
       run: pip install wheel && python setup.py sdist bdist_wheel && ls -l dist
     - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       continue-on-error: true
       with:
         user: __token__
@@ -22,7 +22,7 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
     - name: Publish package to PyPI
       if: "!github.event.release.prerelease"
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
According to [that](https://github.com/pypa/gh-action-pypi-publish/commit/9b8e7336db3f96a2939a3e9fa827c62f466ca60d) `@master` should change to `release/v1`