### PR TITLE
Drop ImageConverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,23 +49,20 @@ How to convert imaging data from standard biomedical formats to group of TileDB 
 
 ### OME-Zarr to TileDB Group of Arrays
 ```python
-from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter
-cnv = OMEZarrConverter()
-cnv.convert_image("path_to_ome_zarr_image", "tiledb_array_group_path")
+from tiledb.bioimg.converters.ome_zarr import OMEZarrReader
+OMEZarrReader.to_tiledb("path_to_ome_zarr_image", "tiledb_array_group_path")
 ```
 
 ### OME-Tiff to TileDB Group of Arrays
 ```python
-from tiledb.bioimg.converters.ome_tiff import OMETiffConverter
-cnv = OMETiffConverter()
-cnv.convert_image("path_to_ome_tiff_image", "tiledb_array_group_path")
+from tiledb.bioimg.converters.ome_tiff import OMETiffReader
+OMETiffReader.to_tiledb("path_to_ome_tiff_image", "tiledb_array_group_path")
 ```
 
 ### Open Slide to TileDB Group of Arrays
 ```python
-from tiledb.bioimg.converters.openslide import OpenSlideConverter
-cnv = OpenSlideConverter()
-cnv.convert_image("path_to_open_slide_image", "tiledb_array_group_path")
+from tiledb.bioimg.converters.openslide import OpenSlideReader
+OpenSlideReader.to_tiledb("path_to_open_slide_image", "tiledb_array_group_path")
 ```
 
 ## Documentation

--- a/examples/OMETiff-convertor-demo.ipynb
+++ b/examples/OMETiff-convertor-demo.ipynb
@@ -21,7 +21,7 @@
     "import matplotlib.pylab as pylab\n",
     "import tiledb\n",
     "\n",
-    "from tiledb.bioimg.converters.ome_tiff import OMETiffConverter\n",
+    "from tiledb.bioimg.converters.ome_tiff import OMETiffReader\n",
     "from tiledb.bioimg.openslide import TileDBOpenSlide"
    ]
   },
@@ -43,7 +43,7 @@
     "src = \"../tests/data/CMU-1-Small-Region.ome.tiff\"\n",
     "dest = src + \".tiledb\"\n",
     "if not os.path.exists(dest):\n",
-    "    OMETiffConverter().to_tiledb(src, dest, level_min=0)"
+    "    OMETiffReader.to_tiledb(src, dest, level_min=0)"
    ]
   },
   {

--- a/examples/OMEZarr-convertor-demo.ipynb
+++ b/examples/OMEZarr-convertor-demo.ipynb
@@ -20,7 +20,7 @@
     "import matplotlib.pylab as pylab\n",
     "import tiledb\n",
     "\n",
-    "from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter\n",
+    "from tiledb.bioimg.converters.ome_zarr import OMEZarrReader\n",
     "from tiledb.bioimg.openslide import TileDBOpenSlide"
    ]
   },
@@ -42,7 +42,7 @@
     "src = \"../tests/data/CMU-1-Small-Region.ome.zarr/0\"\n",
     "dest = src + \".tiledb\"\n",
     "if not os.path.exists(dest):\n",
-    "    OMEZarrConverter().to_tiledb(src, dest, level_min=0)"
+    "    OMEZarrReader.to_tiledb(src, dest, level_min=0)"
    ]
   },
   {

--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -5,12 +5,12 @@ import tifffile
 
 import tiledb
 from tests import get_path, get_schema
-from tiledb.bioimg.converters.ome_tiff import OMETiffConverter
+from tiledb.bioimg.converters.ome_tiff import OMETiffReader, OMETiffWriter
 from tiledb.bioimg.openslide import TileDBOpenSlide
 
 
 def test_ome_tiff_converter(tmp_path):
-    OMETiffConverter().to_tiledb(get_path("CMU-1-Small-Region.ome.tiff"), str(tmp_path))
+    OMETiffReader.to_tiledb(get_path("CMU-1-Small-Region.ome.tiff"), str(tmp_path))
 
     t = TileDBOpenSlide.from_group_uri(str(tmp_path))
     assert len(tiledb.Group(str(tmp_path))) == t.level_count == 2
@@ -32,7 +32,7 @@ def test_ome_tiff_converter(tmp_path):
 
 def test_ome_tiff_converter_different_dtypes(tmp_path):
     path = get_path("rand_uint16.ome.tiff")
-    OMETiffConverter().to_tiledb(path, str(tmp_path))
+    OMETiffReader.to_tiledb(path, str(tmp_path))
 
     assert len(tiledb.Group(str(tmp_path))) == 3
     with tiledb.open(str(tmp_path / "l_0.tdb")) as A:
@@ -51,11 +51,10 @@ def test_tiledb_to_ome_tiff_rountrip(tmp_path):
     tiledb_path = tmp_path / "to_tiledb"
     output_path = tmp_path / "from_tiledb"
 
-    cnv = OMETiffConverter()
     # Store it to Tiledb
-    cnv.to_tiledb(input_path, str(tiledb_path))
+    OMETiffReader.to_tiledb(input_path, str(tiledb_path))
     # Store it back to NGFF Zarr
-    cnv.from_tiledb(str(tiledb_path), output_path)
+    OMETiffWriter.from_tiledb(str(tiledb_path), output_path)
 
     with tifffile.TiffFile(input_path) as t1, tifffile.TiffFile(output_path) as t2:
         compare_tifffiles(t1, t2)
@@ -84,8 +83,7 @@ def test_ome_tiff_converter_artificial_rountrip(tmp_path, filename, dims, tiles)
     tiledb_path = tmp_path / "to_tiledb"
     output_path = tmp_path / "from_tiledb"
 
-    cnv = OMETiffConverter()
-    cnv.to_tiledb(input_path, str(tiledb_path), tiles=tiles)
+    OMETiffReader.to_tiledb(input_path, str(tiledb_path), tiles=tiles)
 
     t = TileDBOpenSlide.from_group_uri(str(tiledb_path))
     assert len(tiledb.Group(str(tiledb_path))) == t.level_count == 1
@@ -102,7 +100,7 @@ def test_ome_tiff_converter_artificial_rountrip(tmp_path, filename, dims, tiles)
         if A.domain.has_dim("T"):
             assert A.dim("T").tile == tiles.get("T", 1)
 
-    cnv.from_tiledb(str(tiledb_path), output_path)
+    OMETiffWriter.from_tiledb(str(tiledb_path), output_path)
     with tifffile.TiffFile(input_path) as t1, tifffile.TiffFile(output_path) as t2:
         compare_tifffiles(t1, t2)
         compare_tiff_page_series(t1.series[0], t2.series[0])

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -7,7 +7,7 @@ import zarr
 
 import tiledb
 from tests import get_path, get_schema
-from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter
+from tiledb.bioimg.converters.ome_zarr import OMEZarrReader, OMEZarrWriter
 from tiledb.bioimg.openslide import TileDBOpenSlide
 
 schemas = (get_schema(2220, 2967), get_schema(387, 463), get_schema(1280, 431))
@@ -16,7 +16,7 @@ schemas = (get_schema(2220, 2967), get_schema(387, 463), get_schema(1280, 431))
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
 def test_ome_zarr_converter(tmp_path, series_idx):
     input_path = get_path("CMU-1-Small-Region.ome.zarr") / str(series_idx)
-    OMEZarrConverter().to_tiledb(input_path, str(tmp_path))
+    OMEZarrReader.to_tiledb(input_path, str(tmp_path))
 
     # check the first (highest) resolution layer only
     schema = schemas[series_idx]
@@ -45,11 +45,10 @@ def test_tiledb_to_ome_zarr_rountrip(tmp_path, series_idx):
     tiledb_path = tmp_path / "to_tiledb"
     output_path = tmp_path / "from_tiledb"
 
-    cnv = OMEZarrConverter()
     # Store it to Tiledb
-    cnv.to_tiledb(input_path, str(tiledb_path))
+    OMEZarrReader.to_tiledb(input_path, str(tiledb_path))
     # Store it back to NGFF Zarr
-    cnv.from_tiledb(str(tiledb_path), output_path)
+    OMEZarrWriter.from_tiledb(str(tiledb_path), output_path)
 
     # Same number of levels
     input_group = zarr.open_group(input_path, mode="r")

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -4,13 +4,13 @@ import PIL.Image
 
 import tiledb
 from tests import get_path, get_schema
-from tiledb.bioimg.converters.openslide import OpenSlideConverter
+from tiledb.bioimg.converters.openslide import OpenSlideReader
 from tiledb.bioimg.openslide import TileDBOpenSlide
 
 
 def test_openslide_converter(tmp_path):
     svs_path = get_path("CMU-1-Small-Region.svs")
-    OpenSlideConverter().to_tiledb(svs_path, str(tmp_path))
+    OpenSlideReader.to_tiledb(svs_path, str(tmp_path))
 
     assert len(tiledb.Group(str(tmp_path))) == 1
     with tiledb.open(str(tmp_path / "l_0.tdb")) as A:

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -14,6 +14,96 @@ from .axes import Axes, transpose_array
 
 
 class ImageReader(ABC):
+    _DEFAULT_TILES = {"T": 1, "C": 3, "Z": 1, "Y": 1024, "X": 1024}
+
+    @classmethod
+    def to_tiledb(
+        cls,
+        input_path: str,
+        output_path: str,
+        *,
+        level_min: int = 0,
+        tiles: Mapping[str, int] = {},
+        preserve_axes: bool = False,
+    ) -> None:
+        """
+        Convert an image to a TileDB Group of Arrays, one per level.
+
+        :param input_path: path to the input image
+        :param output_path: path to the TileDB group of arrays
+        :param level_min: minimum level of the image to be converted. By default set to 0
+            to convert all levels.
+        :param tiles: A mapping from dimension name (one of 'T', 'C', 'Z', 'Y', 'X') to
+            the (maximum) tile for this dimension.
+        :param preserve_axes: If true, preserve the axes order of the original image.
+        """
+        tiledb.group_create(output_path)
+        with cls(input_path) as reader:
+            axes = reader.axes
+            # Create a TileDB array for each level in range(level_min, reader.level_count)
+            uris = []
+            for level in range(level_min, reader.level_count):
+                # read metadata and image
+                metadata = reader.level_metadata(level)
+                image = reader.level_image(level)
+                # determine axes and (optionally) transpose image to canonical axes
+                if preserve_axes:
+                    level_axes = axes
+                else:
+                    level_axes = axes.canonical(image)
+                    image = transpose_array(image, axes.dims, level_axes.dims)
+                # create TileDB array
+                uri = os.path.join(output_path, f"l_{level}.tdb")
+                schema = cls._get_schema(image, level_axes, tiles)
+                tiledb.Array.create(uri, schema)
+                # write image and metadata to TileDB array
+                with tiledb.open(uri, "w") as a:
+                    a[:] = image
+                    a.meta.update(metadata, level=level)
+                uris.append(uri)
+
+            # Write group metadata
+            with tiledb.Group(output_path, "w") as group:
+                group.meta.update(reader.group_metadata, axes=axes.dims)
+                for level_uri in uris:
+                    if urlparse(level_uri).scheme == "tiledb":
+                        group.add(level_uri, relative=False)
+                    else:
+                        group.add(os.path.basename(level_uri), relative=True)
+
+    @classmethod
+    def _get_schema(
+        cls, image: np.ndarray, axes: Axes, tiles: Mapping[str, int]
+    ) -> tiledb.ArraySchema:
+        # find the smallest dtype that can hold the number of image scalar values
+        dim_dtype = np.min_scalar_type(image.size)
+        dims = []
+        assert len(axes.dims) == len(image.shape)
+        for dim_name, dim_size in zip(axes.dims, image.shape):
+            max_tile = tiles.get(dim_name, cls._DEFAULT_TILES[dim_name])
+            dims.append(
+                tiledb.Dim(
+                    dim_name,
+                    domain=(0, dim_size - 1),
+                    dtype=dim_dtype,
+                    tile=min(dim_size, max_tile),
+                )
+            )
+        return tiledb.ArraySchema(
+            domain=tiledb.Domain(*dims),
+            attrs=[
+                tiledb.Attr(
+                    name="",
+                    dtype=image.dtype,
+                    filters=[tiledb.ZstdFilter(level=0)],
+                )
+            ],
+        )
+
+    @abstractmethod
+    def __init__(self, input_path: str):
+        """Initialize this ImageReader"""
+
     def __enter__(self) -> ImageReader:
         return self
 
@@ -53,35 +143,9 @@ class ImageReader(ABC):
 
 
 class ImageWriter(ABC):
-    def __enter__(self) -> ImageWriter:
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        pass
-
-    @abstractmethod
-    def write_group_metadata(self, metadata: Mapping[str, Any]) -> None:
-        """Write metadata for the whole multi-resolution image."""
-
-    @abstractmethod
-    def write_level_image(
-        self, level: int, image: np.ndarray, metadata: Mapping[str, Any]
-    ) -> None:
-        """
-        Write the image for the given level.
-
-        :param level: Number corresponding to a level
-        :param image: Image for the given level as numpy array
-        :param metadata: Metadata for the given level
-        """
-
-
-class ImageConverter(ABC):
-
-    _DEFAULT_TILES = {"T": 1, "C": 3, "Z": 1, "Y": 1024, "X": 1024}
-
+    @classmethod
     def from_tiledb(
-        self, input_path: str, output_path: str, *, level_min: int = 0
+        cls, input_path: str, output_path: str, *, level_min: int = 0
     ) -> None:
         """
         Convert a TileDB Group of Arrays back to other format images, one per level.
@@ -103,7 +167,7 @@ class ImageConverter(ABC):
             level_arrays.append((level, array))
         level_arrays.sort(key=itemgetter(0))
 
-        with self._get_image_writer(output_path) as writer:
+        with cls(output_path) as writer:
             writer.write_group_metadata(group.meta)
             original_axes = Axes(group.meta["axes"])
             for level, array in level_arrays:
@@ -114,92 +178,28 @@ class ImageConverter(ABC):
                 writer.write_level_image(level, image, array.meta)
                 array.close()
 
-    def to_tiledb(
-        self,
-        input_path: str,
-        output_group_path: str,
-        *,
-        level_min: int = 0,
-        tiles: Mapping[str, int] = {},
-        preserve_axes: bool = False,
+    @abstractmethod
+    def __init__(self, output_path: str):
+        """Initialize this ImageWriter"""
+
+    def __enter__(self) -> ImageWriter:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        pass
+
+    @abstractmethod
+    def write_group_metadata(self, metadata: Mapping[str, Any]) -> None:
+        """Write metadata for the whole multi-resolution image."""
+
+    @abstractmethod
+    def write_level_image(
+        self, level: int, image: np.ndarray, metadata: Mapping[str, Any]
     ) -> None:
         """
-        Convert an image to a TileDB Group of Arrays, one per level.
+        Write the image for the given level.
 
-        :param input_path: path to the input image
-        :param output_group_path: path to the TileDB group of arrays
-        :param level_min: minimum level of the image to be converted. By default set to 0
-            to convert all levels.
-        :param tiles: A mapping from dimension name (one of 'T', 'C', 'Z', 'Y', 'X') to
-            the (maximum) tile for this dimension.
-        :param preserve_axes: If true, preserve the axes order of the original image.
+        :param level: Number corresponding to a level
+        :param image: Image for the given level as numpy array
+        :param metadata: Metadata for the given level
         """
-        tiledb.group_create(output_group_path)
-        with self._get_image_reader(input_path) as reader:
-            axes = reader.axes
-            # Create a TileDB array for each level in range(level_min, reader.level_count)
-            uris = []
-            for level in range(level_min, reader.level_count):
-                # read metadata and image
-                metadata = reader.level_metadata(level)
-                image = reader.level_image(level)
-                # determine axes and (optionally) transpose image to canonical axes
-                if preserve_axes:
-                    level_axes = axes
-                else:
-                    level_axes = axes.canonical(image)
-                    image = transpose_array(image, axes.dims, level_axes.dims)
-                # create TileDB array
-                uri = os.path.join(output_group_path, f"l_{level}.tdb")
-                schema = self._get_schema(image, level_axes, tiles)
-                tiledb.Array.create(uri, schema)
-                # write image and metadata to TileDB array
-                with tiledb.open(uri, "w") as a:
-                    a[:] = image
-                    a.meta.update(metadata, level=level)
-                uris.append(uri)
-
-            # Write group metadata
-            with tiledb.Group(output_group_path, "w") as group:
-                group.meta.update(reader.group_metadata, axes=axes.dims)
-                for level_uri in uris:
-                    if urlparse(level_uri).scheme == "tiledb":
-                        group.add(level_uri, relative=False)
-                    else:
-                        group.add(os.path.basename(level_uri), relative=True)
-
-    def _get_schema(
-        self, image: np.ndarray, axes: Axes, tiles: Mapping[str, int]
-    ) -> tiledb.ArraySchema:
-        # find the smallest dtype that can hold the number of image scalar values
-        dim_dtype = np.min_scalar_type(image.size)
-        dims = []
-        assert len(axes.dims) == len(image.shape)
-        for dim_name, dim_size in zip(axes.dims, image.shape):
-            max_tile = tiles.get(dim_name, self._DEFAULT_TILES[dim_name])
-            dims.append(
-                tiledb.Dim(
-                    dim_name,
-                    domain=(0, dim_size - 1),
-                    dtype=dim_dtype,
-                    tile=min(dim_size, max_tile),
-                )
-            )
-        return tiledb.ArraySchema(
-            domain=tiledb.Domain(*dims),
-            attrs=[
-                tiledb.Attr(
-                    name="",
-                    dtype=image.dtype,
-                    filters=[tiledb.ZstdFilter(level=0)],
-                )
-            ],
-        )
-
-    @abstractmethod
-    def _get_image_writer(self, output_path: str) -> ImageWriter:
-        """Return an ImageWriter for the given input path."""
-
-    @abstractmethod
-    def _get_image_reader(self, input_path: str) -> ImageReader:
-        """Return an ImageReader for the given input path."""

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Mapping
 import numpy as np
 import tifffile
 
-from .base import Axes, ImageConverter, ImageReader, ImageWriter
+from .base import Axes, ImageReader, ImageWriter
 
 
 class OMETiffReader(ImageReader):
@@ -76,7 +76,7 @@ class OMETiffReader(ImageReader):
         return {"pickled_tiffwriter_kwargs": pickle.dumps(writer_kwargs)}
 
 
-class OmeTiffWriter(ImageWriter):
+class OMETiffWriter(ImageWriter):
     def __init__(self, output_path: str):
         self._output_path = output_path
 
@@ -102,13 +102,3 @@ class OmeTiffWriter(ImageWriter):
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self._writer.close()
-
-
-class OMETiffConverter(ImageConverter):
-    """Converter of Tiff-supported images to TileDB Groups of Arrays"""
-
-    def _get_image_reader(self, input_path: str) -> ImageReader:
-        return OMETiffReader(input_path)
-
-    def _get_image_writer(self, output_path: str) -> ImageWriter:
-        return OmeTiffWriter(output_path)

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -10,7 +10,7 @@ from numcodecs import Blosc
 from ome_zarr.reader import Reader, ZarrLocation
 from ome_zarr.writer import write_multiscale
 
-from .base import Axes, ImageConverter, ImageReader, ImageWriter
+from .base import Axes, ImageReader, ImageWriter
 
 
 class OMEZarrReader(ImageReader):
@@ -105,13 +105,3 @@ class OMEZarrWriter(ImageWriter):
         )
         if group_metadata["omero"]:
             self._group.attrs["omero"] = group_metadata["omero"]
-
-
-class OMEZarrConverter(ImageConverter):
-    """Converter of Zarr-supported images to TileDB Groups of Arrays"""
-
-    def _get_image_reader(self, input_path: str) -> ImageReader:
-        return OMEZarrReader(input_path)
-
-    def _get_image_writer(self, output_path: str) -> ImageWriter:
-        return OMEZarrWriter(output_path)

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, cast
 import numpy as np
 import openslide as osd
 
-from .base import Axes, ImageConverter, ImageReader, ImageWriter
+from .base import Axes, ImageReader
 
 
 class OpenSlideReader(ImageReader):
@@ -41,13 +41,3 @@ class OpenSlideReader(ImageReader):
     @property
     def group_metadata(self) -> Dict[str, Any]:
         return {}
-
-
-class OpenSlideConverter(ImageConverter):
-    """Converter of OpenSlide-supported images to TileDB Groups of Arrays"""
-
-    def _get_image_reader(self, input_path: str) -> ImageReader:
-        return OpenSlideReader(input_path)
-
-    def _get_image_writer(self, output_path: str) -> ImageWriter:
-        raise NotImplementedError


### PR DESCRIPTION
`ImageConverter` (& subclasses) doesn't really carry its weight:
- its instances have minimal state (zero after https://github.com/TileDB-Inc/TileDB-BioImaging/pull/38) 
- their two methods `to_tiledb` and `from_tiledb` are pretty much independent and better exposed as classmethods to `ImageReader` and `ImageWriter` respectively.