### PR TITLE
Refactor ImageConverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,22 +50,19 @@ How to convert imaging data from standard biomedical formats to group of TileDB 
 ### OME-Zarr to TileDB Group of Arrays
 ```python
 from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter
-cnv = OMEZarrConverter()
-cnv.convert_image("path_to_ome_zarr_image", "tiledb_array_group_path")
+OMEZarrConverter.to_tiledb("path_to_ome_zarr_image", "tiledb_array_group_path")
 ```
 
 ### OME-Tiff to TileDB Group of Arrays
 ```python
 from tiledb.bioimg.converters.ome_tiff import OMETiffConverter
-cnv = OMETiffConverter()
-cnv.convert_image("path_to_ome_tiff_image", "tiledb_array_group_path")
+OMETiffConverter.to_tiledb("path_to_ome_tiff_image", "tiledb_array_group_path")
 ```
 
 ### Open Slide to TileDB Group of Arrays
 ```python
 from tiledb.bioimg.converters.openslide import OpenSlideConverter
-cnv = OpenSlideConverter()
-cnv.convert_image("path_to_open_slide_image", "tiledb_array_group_path")
+OpenSlideConverter.to_tiledb("path_to_open_slide_image", "tiledb_array_group_path")
 ```
 
 ## Documentation

--- a/examples/OMETiff-convertor-demo.ipynb
+++ b/examples/OMETiff-convertor-demo.ipynb
@@ -43,7 +43,7 @@
     "src = \"../tests/data/CMU-1-Small-Region.ome.tiff\"\n",
     "dest = src + \".tiledb\"\n",
     "if not os.path.exists(dest):\n",
-    "    OMETiffConverter().to_tiledb(src, dest, level_min=0)"
+    "    OMETiffConverter.to_tiledb(src, dest, level_min=0)"
    ]
   },
   {

--- a/examples/OMEZarr-convertor-demo.ipynb
+++ b/examples/OMEZarr-convertor-demo.ipynb
@@ -42,7 +42,7 @@
     "src = \"../tests/data/CMU-1-Small-Region.ome.zarr/0\"\n",
     "dest = src + \".tiledb\"\n",
     "if not os.path.exists(dest):\n",
-    "    OMEZarrConverter().to_tiledb(src, dest, level_min=0)"
+    "    OMEZarrConverter.to_tiledb(src, dest, level_min=0)"
    ]
   },
   {

--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -10,7 +10,7 @@ from tiledb.bioimg.openslide import TileDBOpenSlide
 
 
 def test_ome_tiff_converter(tmp_path):
-    OMETiffConverter().to_tiledb(get_path("CMU-1-Small-Region.ome.tiff"), str(tmp_path))
+    OMETiffConverter.to_tiledb(get_path("CMU-1-Small-Region.ome.tiff"), str(tmp_path))
 
     t = TileDBOpenSlide.from_group_uri(str(tmp_path))
     assert len(tiledb.Group(str(tmp_path))) == t.level_count == 2
@@ -32,7 +32,7 @@ def test_ome_tiff_converter(tmp_path):
 
 def test_ome_tiff_converter_different_dtypes(tmp_path):
     path = get_path("rand_uint16.ome.tiff")
-    OMETiffConverter().to_tiledb(path, str(tmp_path))
+    OMETiffConverter.to_tiledb(path, str(tmp_path))
 
     assert len(tiledb.Group(str(tmp_path))) == 3
     with tiledb.open(str(tmp_path / "l_0.tdb")) as A:
@@ -51,11 +51,10 @@ def test_tiledb_to_ome_tiff_rountrip(tmp_path):
     tiledb_path = tmp_path / "to_tiledb"
     output_path = tmp_path / "from_tiledb"
 
-    cnv = OMETiffConverter()
     # Store it to Tiledb
-    cnv.to_tiledb(input_path, str(tiledb_path))
+    OMETiffConverter.to_tiledb(input_path, str(tiledb_path))
     # Store it back to NGFF Zarr
-    cnv.from_tiledb(str(tiledb_path), output_path)
+    OMETiffConverter.from_tiledb(str(tiledb_path), output_path)
 
     with tifffile.TiffFile(input_path) as t1, tifffile.TiffFile(output_path) as t2:
         compare_tifffiles(t1, t2)
@@ -84,8 +83,7 @@ def test_ome_tiff_converter_artificial_rountrip(tmp_path, filename, dims, tiles)
     tiledb_path = tmp_path / "to_tiledb"
     output_path = tmp_path / "from_tiledb"
 
-    cnv = OMETiffConverter()
-    cnv.to_tiledb(input_path, str(tiledb_path), tiles=tiles)
+    OMETiffConverter.to_tiledb(input_path, str(tiledb_path), tiles=tiles)
 
     t = TileDBOpenSlide.from_group_uri(str(tiledb_path))
     assert len(tiledb.Group(str(tiledb_path))) == t.level_count == 1
@@ -102,7 +100,7 @@ def test_ome_tiff_converter_artificial_rountrip(tmp_path, filename, dims, tiles)
         if A.domain.has_dim("T"):
             assert A.dim("T").tile == tiles.get("T", 1)
 
-    cnv.from_tiledb(str(tiledb_path), output_path)
+    OMETiffConverter.from_tiledb(str(tiledb_path), output_path)
     with tifffile.TiffFile(input_path) as t1, tifffile.TiffFile(output_path) as t2:
         compare_tifffiles(t1, t2)
         compare_tiff_page_series(t1.series[0], t2.series[0])

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -16,7 +16,7 @@ schemas = (get_schema(2220, 2967), get_schema(387, 463), get_schema(1280, 431))
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
 def test_ome_zarr_converter(tmp_path, series_idx):
     input_path = get_path("CMU-1-Small-Region.ome.zarr") / str(series_idx)
-    OMEZarrConverter().to_tiledb(input_path, str(tmp_path))
+    OMEZarrConverter.to_tiledb(input_path, str(tmp_path))
 
     # check the first (highest) resolution layer only
     schema = schemas[series_idx]
@@ -45,11 +45,10 @@ def test_tiledb_to_ome_zarr_rountrip(tmp_path, series_idx):
     tiledb_path = tmp_path / "to_tiledb"
     output_path = tmp_path / "from_tiledb"
 
-    cnv = OMEZarrConverter()
     # Store it to Tiledb
-    cnv.to_tiledb(input_path, str(tiledb_path))
+    OMEZarrConverter.to_tiledb(input_path, str(tiledb_path))
     # Store it back to NGFF Zarr
-    cnv.from_tiledb(str(tiledb_path), output_path)
+    OMEZarrConverter.from_tiledb(str(tiledb_path), output_path)
 
     # Same number of levels
     input_group = zarr.open_group(input_path, mode="r")

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -10,7 +10,7 @@ from tiledb.bioimg.openslide import TileDBOpenSlide
 
 def test_openslide_converter(tmp_path):
     svs_path = get_path("CMU-1-Small-Region.svs")
-    OpenSlideConverter().to_tiledb(svs_path, str(tmp_path))
+    OpenSlideConverter.to_tiledb(svs_path, str(tmp_path))
 
     assert len(tiledb.Group(str(tmp_path))) == 1
     with tiledb.open(str(tmp_path / "l_0.tdb")) as A:

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -76,7 +76,7 @@ class OMETiffReader(ImageReader):
         return {"pickled_tiffwriter_kwargs": pickle.dumps(writer_kwargs)}
 
 
-class OmeTiffWriter(ImageWriter):
+class OMETiffWriter(ImageWriter):
     def __init__(self, output_path: str):
         self._output_path = output_path
 
@@ -107,8 +107,5 @@ class OmeTiffWriter(ImageWriter):
 class OMETiffConverter(ImageConverter):
     """Converter of Tiff-supported images to TileDB Groups of Arrays"""
 
-    def _get_image_reader(self, input_path: str) -> ImageReader:
-        return OMETiffReader(input_path)
-
-    def _get_image_writer(self, output_path: str) -> ImageWriter:
-        return OmeTiffWriter(output_path)
+    _ImageReaderType = OMETiffReader
+    _ImageWriterType = OMETiffWriter

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -110,8 +110,5 @@ class OMEZarrWriter(ImageWriter):
 class OMEZarrConverter(ImageConverter):
     """Converter of Zarr-supported images to TileDB Groups of Arrays"""
 
-    def _get_image_reader(self, input_path: str) -> ImageReader:
-        return OMEZarrReader(input_path)
-
-    def _get_image_writer(self, output_path: str) -> ImageWriter:
-        return OMEZarrWriter(output_path)
+    _ImageReaderType = OMEZarrReader
+    _ImageWriterType = OMEZarrWriter

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, cast
 import numpy as np
 import openslide as osd
 
-from .base import Axes, ImageConverter, ImageReader, ImageWriter
+from .base import Axes, ImageConverter, ImageReader
 
 
 class OpenSlideReader(ImageReader):
@@ -46,8 +46,4 @@ class OpenSlideReader(ImageReader):
 class OpenSlideConverter(ImageConverter):
     """Converter of OpenSlide-supported images to TileDB Groups of Arrays"""
 
-    def _get_image_reader(self, input_path: str) -> ImageReader:
-        return OpenSlideReader(input_path)
-
-    def _get_image_writer(self, output_path: str) -> ImageWriter:
-        raise NotImplementedError
+    _ImageReaderType = OpenSlideReader


### PR DESCRIPTION
`ImageConverter` (and its subclasses) instances have minimal state (actually zero after https://github.com/TileDB-Inc/TileDB-BioImaging/pull/38). This PR changes its methods (`to_tiledb`, `from_tiledb`) to classmethods.