### PR TITLE
TileDBOpenSlide context manager

### DIFF
--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -9,11 +9,18 @@ from tiledb.bioimg.converters.ome_tiff import OMETiffConverter
 from tiledb.bioimg.openslide import TileDBOpenSlide
 
 
-def test_ome_tiff_converter(tmp_path):
-    OMETiffConverter.to_tiledb(get_path("CMU-1-Small-Region.ome.tiff"), str(tmp_path))
+@pytest.mark.parametrize("open_fileobj", [False, True])
+def test_ome_tiff_converter(tmp_path, open_fileobj):
+    input_path = str(get_path("CMU-1-Small-Region.ome.tiff"))
+    output_path = str(tmp_path)
+    if open_fileobj:
+        with open(input_path, "rb") as f:
+            OMETiffConverter.to_tiledb(f, output_path)
+    else:
+        OMETiffConverter.to_tiledb(input_path, output_path)
 
-    t = TileDBOpenSlide.from_group_uri(str(tmp_path))
-    assert len(tiledb.Group(str(tmp_path))) == t.level_count == 2
+    t = TileDBOpenSlide.from_group_uri(output_path)
+    assert len(tiledb.Group(output_path)) == t.level_count == 2
 
     schemas = (get_schema(2220, 2967), get_schema(574, 768))
     assert t.dimensions == schemas[0].shape[:-3:-1]

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -23,20 +23,20 @@ def test_ome_zarr_converter(tmp_path, series_idx):
     with tiledb.open(str(tmp_path / "l_0.tdb")) as A:
         assert A.schema == schema
 
-    t = TileDBOpenSlide.from_group_uri(str(tmp_path))
-    assert t.dimensions == t.level_dimensions[0] == schema.shape[:-3:-1]
+    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
+        assert t.dimensions == t.level_dimensions[0] == schema.shape[:-3:-1]
 
-    region_location = (100, 100)
-    region_size = (300, 400)
-    region = t.read_region(level=0, location=region_location, size=region_size)
-    assert isinstance(region, np.ndarray)
-    assert region.ndim == 3
-    assert region.dtype == np.uint8
-    img = PIL.Image.fromarray(region)
-    assert img.size == (
-        min(t.dimensions[0] - region_location[0], region_size[0]),
-        min(t.dimensions[1] - region_location[1], region_size[1]),
-    )
+        region_location = (100, 100)
+        region_size = (300, 400)
+        region = t.read_region(level=0, location=region_location, size=region_size)
+        assert isinstance(region, np.ndarray)
+        assert region.ndim == 3
+        assert region.dtype == np.uint8
+        img = PIL.Image.fromarray(region)
+        assert img.size == (
+            min(t.dimensions[0] - region_location[0], region_size[0]),
+            min(t.dimensions[1] - region_location[1], region_size[1]),
+        )
 
 
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
@@ -87,13 +87,13 @@ def test_ome_zarr_converter_incremental(tmp_path):
     input_path = get_path("CMU-1-Small-Region.ome.zarr/0")
 
     OMEZarrConverter.to_tiledb(input_path, str(tmp_path), level_min=1)
-    t = TileDBOpenSlide.from_group_uri(str(tmp_path))
-    assert len(tiledb.Group(str(tmp_path))) == t.level_count == 1
+    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
+        assert len(tiledb.Group(str(tmp_path))) == t.level_count == 1
 
     OMEZarrConverter.to_tiledb(input_path, str(tmp_path), level_min=0)
-    t = TileDBOpenSlide.from_group_uri(str(tmp_path))
-    assert len(tiledb.Group(str(tmp_path))) == t.level_count == 2
+    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
+        assert len(tiledb.Group(str(tmp_path))) == t.level_count == 2
 
     OMEZarrConverter.to_tiledb(input_path, str(tmp_path), level_min=0)
-    t = TileDBOpenSlide.from_group_uri(str(tmp_path))
-    assert len(tiledb.Group(str(tmp_path))) == t.level_count == 2
+    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
+        assert len(tiledb.Group(str(tmp_path))) == t.level_count == 2

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -17,16 +17,16 @@ def test_openslide_converter(tmp_path):
         assert A.schema == get_schema(2220, 2967)
 
     o = openslide.open_slide(svs_path)
-    t = TileDBOpenSlide.from_group_uri(str(tmp_path))
+    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
 
-    assert t.level_count == o.level_count
-    assert t.dimensions == o.dimensions
-    assert t.level_dimensions == o.level_dimensions
-    assert t.level_downsamples == o.level_downsamples
+        assert t.level_count == o.level_count
+        assert t.dimensions == o.dimensions
+        assert t.level_dimensions == o.level_dimensions
+        assert t.level_downsamples == o.level_downsamples
 
-    region = t.read_region(level=0, location=(100, 100), size=(300, 400))
-    assert isinstance(region, np.ndarray)
-    assert region.ndim == 3
-    assert region.dtype == np.uint8
-    img = PIL.Image.fromarray(region)
-    assert img.size == (300, 400)
+        region = t.read_region(level=0, location=(100, 100), size=(300, 400))
+        assert isinstance(region, np.ndarray)
+        assert region.ndim == 3
+        assert region.dtype == np.uint8
+        img = PIL.Image.fromarray(region)
+        assert img.size == (300, 400)

--- a/tests/unit/test_openslide.py
+++ b/tests/unit/test_openslide.py
@@ -22,6 +22,6 @@ class TestTileDBOpenSlide:
                     A.meta["level"] = level
                 G.add(level_path)
 
-        tdb_os = TileDBOpenSlide.from_group_uri(group_path)
-        assert tdb_os.level_count == len(level_dimensions)
-        assert tdb_os.level_dimensions == tuple(level_dimensions)
+        with TileDBOpenSlide.from_group_uri(group_path) as t:
+            assert t.level_count == len(level_dimensions)
+            assert t.level_dimensions == tuple(level_dimensions)


### PR DESCRIPTION
- Change `TileDBOpenSlide.__init__` to accept (open) TileDB image level arrays instead of opening & closing them on every `read_region` call.
-  Make `TileDBOpenSlide` a context manager for closing the image level arrays in a clean manner:
```py
with TileDBOpenSlide.from_group_uri(uri) as t:
   ...
```
