### PR TITLE
Replace Levenshtein dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
         "local_scheme": "dirty-tag",
         "write_to": "tiledb/bioimg/version.py",
     },
-    install_requires=["edit_operation", "tiledb"],
+    install_requires=["pyeditdistance", "tiledb"],
     extras_require={
         "zarr": zarr,
         "openslide": openslide,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
         "local_scheme": "dirty-tag",
         "write_to": "tiledb/bioimg/version.py",
     },
-    install_requires=["levenshtein", "tiledb"],
+    install_requires=["edit_operation", "tiledb"],
     extras_require={
         "zarr": zarr,
         "openslide": openslide,

--- a/tests/unit/test_axes.py
+++ b/tests/unit/test_axes.py
@@ -14,32 +14,32 @@ from tiledb.bioimg.converters.axes import (
 
 class TestTranspositions:
     @pytest.mark.parametrize(
-        "s,i,j", [("ADCBE", 1, 3), ("DBCAE", 3, 0), ("ACBDE", 2, 1)]
+        "s,i,j", [(b"ADCBE", 1, 3), (b"DBCAE", 3, 0), (b"ACBDE", 2, 1)]
     )
     def test_swap(self, s, i, j):
         swap = Swap(i, j)
-        assert swap.transposed(s) == list("ABCDE")
-        b = list(s)
+        assert swap.transposed(s) == b"ABCDE"
+        b = bytearray(s)
         assert swap.transpose(b) is None
-        assert b == list("ABCDE")
+        assert b == b"ABCDE"
 
     @pytest.mark.parametrize(
         "s,i,j",
         [
-            ("ADBCE", 1, 3),
-            ("ACDBE", 3, 1),
-            ("ACBDE", 1, 2),
-            ("ACBDE", 2, 1),
-            ("EABCD", 0, 4),
-            ("BCDEA", 4, 0),
+            (b"ADBCE", 1, 3),
+            (b"ACDBE", 3, 1),
+            (b"ACBDE", 1, 2),
+            (b"ACBDE", 2, 1),
+            (b"EABCD", 0, 4),
+            (b"BCDEA", 4, 0),
         ],
     )
     def test_move(self, s, i, j):
         move = Move(i, j)
-        assert move.transposed(s) == list("ABCDE")
-        b = list(s)
+        assert move.transposed(s) == b"ABCDE"
+        b = bytearray(s)
         assert move.transpose(b) is None
-        assert b == list("ABCDE")
+        assert b == b"ABCDE"
 
     @pytest.mark.parametrize(
         "s,t,transpositions",
@@ -52,10 +52,10 @@ class TestTranspositions:
     )
     def test_minimize_transpositions(self, s, t, transpositions):
         assert minimize_transpositions(s, t) == transpositions
-        s = list(s)
+        b = bytearray(s.encode())
         for transposition in transpositions:
-            transposition.transpose(s)
-        assert s == list(t)
+            transposition.transpose(b)
+        assert b.decode() == t
 
 
 class TestAxes:

--- a/tiledb/bioimg/converters/axes.py
+++ b/tiledb/bioimg/converters/axes.py
@@ -7,7 +7,7 @@ from operator import itemgetter
 from typing import Iterable, Iterator, Sequence
 
 import numpy as np
-from edit_operation import levenshtein
+from pyeditdistance.distance import levenshtein
 
 
 @dataclass(frozen=True)
@@ -93,7 +93,7 @@ def minimize_transpositions(s: str, t: str) -> Sequence[Transpose]:
     transpositions = []
     while sbuf != tbuf:
         weighted_transpositions = (
-            (levenshtein.distance(tr.transposed(sbuf).decode(), t), tr)
+            (levenshtein(tr.transposed(sbuf).decode(), t), tr)
             for tr in gen_transpositions(n)
         )
         best_transposition = min(weighted_transpositions, key=itemgetter(0))[1]

--- a/tiledb/bioimg/openslide.py
+++ b/tiledb/bioimg/openslide.py
@@ -88,7 +88,7 @@ class TileDBOpenSlide:
         w, h = size
         dim_to_slice = {"X": slice(x, x + w), "Y": slice(y, y + h)}
         array = self._level_arrays[level]
-        dims = [dim.name for dim in array.domain]
+        dims = "".join(dim.name for dim in array.domain)
         image = array[tuple(dim_to_slice.get(dim, slice(None)) for dim in dims)]
         # transpose image to YXC
         return transpose_array(image, dims, "YXC")


### PR DESCRIPTION
Replace [Levenshtein](https://pypi.org/project/Levenshtein/) (GPL) with ~[edit-operation](https://pypi.org/project/edit-operation/)~ [pyeditdistance](https://pypi.org/project/pyeditdistance/) (MIT). 

Note: Unlike `Levenshtein` that can compare arbitrary sequences, `edit-operation` can compare only strings, so the `Transpose` API and related functions were adjusted accordingly.