### PR TITLE
Replace openslide-python with tiffslide

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 zarr = ["ome-zarr"]
-openslide = ["openslide-python"]
+openslide = ["tiffslide"]
 tiff = ["tifffile", "imagecodecs"]
 full = sorted({*zarr, *openslide, *tiff})
 

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -1,6 +1,6 @@
 import numpy as np
-import openslide
 import PIL.Image
+import tiffslide
 
 import tiledb
 from tests import get_path, get_schema
@@ -16,7 +16,7 @@ def test_openslide_converter(tmp_path):
     with tiledb.open(str(tmp_path / "l_0.tdb")) as A:
         assert A.schema == get_schema(2220, 2967)
 
-    o = openslide.open_slide(svs_path)
+    o = tiffslide.TiffSlide(svs_path)
     with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
 
         assert t.level_count == o.level_count

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, cast
 
 import numpy as np
-import openslide as osd
+import tiffslide
 
 from .base import Axes, ImageConverter, ImageReader
 
@@ -14,7 +14,7 @@ class OpenSlideReader(ImageReader):
         :param input_path: The path to the OpenSlide image
 
         """
-        self._osd = osd.OpenSlide(input_path)
+        self._osd = tiffslide.TiffSlide(input_path)
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self._osd.close()


### PR DESCRIPTION
Swap [openslide-python](https://github.com/openslide/openslide-python) with [tiffslide](https://github.com/bayer-science-for-a-better-life/tiffslide), a drop-in replacement based on [tifffile](https://github.com/cgohlke/tifffile) instead of the [OpenSlide](https://openslide.org/) C library.