### PR TITLE
Chunked ingestion

### DIFF
--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -55,13 +55,21 @@ def test_ome_tiff_converter_different_dtypes(tmp_path):
         assert A.attr(0).dtype == np.uint16
 
 
-def test_tiledb_to_ome_tiff_rountrip(tmp_path):
+@pytest.mark.parametrize("preserve_axes", [False, True])
+@pytest.mark.parametrize("chunked", [False, True])
+def test_tiledb_to_ome_tiff_rountrip(tmp_path, preserve_axes, chunked):
     input_path = get_path("CMU-1-Small-Region.ome.tiff")
     tiledb_path = tmp_path / "to_tiledb"
     output_path = tmp_path / "from_tiledb"
+    to_tiledb_kwargs = dict(
+        input_path=input_path,
+        output_path=str(tiledb_path),
+        preserve_axes=preserve_axes,
+        chunked=chunked,
+    )
 
     # Store it to Tiledb
-    OMETiffConverter.to_tiledb(input_path, str(tiledb_path))
+    OMETiffConverter.to_tiledb(**to_tiledb_kwargs)
     # Store it back to NGFF Zarr
     OMETiffConverter.from_tiledb(str(tiledb_path), output_path)
 

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -42,13 +42,25 @@ def test_ome_zarr_converter(tmp_path, series_idx, preserve_axes):
 
 
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
-def test_tiledb_to_ome_zarr_rountrip(tmp_path, series_idx):
+@pytest.mark.parametrize("preserve_axes", [False, True])
+@pytest.mark.parametrize("chunked", [False, True])
+def test_tiledb_to_ome_zarr_rountrip(tmp_path, series_idx, preserve_axes, chunked):
     input_path = get_path("CMU-1-Small-Region.ome.zarr") / str(series_idx)
     tiledb_path = tmp_path / "to_tiledb"
     output_path = tmp_path / "from_tiledb"
+    to_tiledb_kwargs = dict(
+        input_path=input_path,
+        output_path=str(tiledb_path),
+        preserve_axes=preserve_axes,
+        chunked=chunked,
+    )
+    if chunked and not preserve_axes:
+        with pytest.raises(NotImplementedError):
+            OMEZarrConverter.to_tiledb(**to_tiledb_kwargs)
+        return
 
     # Store it to Tiledb
-    OMEZarrConverter.to_tiledb(input_path, str(tiledb_path))
+    OMEZarrConverter.to_tiledb(**to_tiledb_kwargs)
     # Store it back to NGFF Zarr
     OMEZarrConverter.from_tiledb(str(tiledb_path), output_path)
 

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -10,26 +10,40 @@ from tiledb.bioimg.openslide import TileDBOpenSlide
 
 
 @pytest.mark.parametrize("preserve_axes", [False, True])
-def test_openslide_converter(tmp_path, preserve_axes):
-    svs_path = get_path("CMU-1-Small-Region.svs")
-    OpenSlideConverter.to_tiledb(svs_path, str(tmp_path), preserve_axes=preserve_axes)
+@pytest.mark.parametrize("chunked", [False, True])
+def test_openslide_converter(tmp_path, preserve_axes, chunked):
+    input_path = get_path("CMU-1-Small-Region.svs")
+    output_path = str(tmp_path)
+    to_tiledb_kwargs = dict(
+        input_path=input_path,
+        output_path=output_path,
+        preserve_axes=preserve_axes,
+        chunked=chunked,
+    )
+    if chunked and not preserve_axes:
+        with pytest.raises(NotImplementedError):
+            OpenSlideConverter.to_tiledb(**to_tiledb_kwargs)
+        return
 
-    assert len(tiledb.Group(str(tmp_path))) == 1
+    OpenSlideConverter.to_tiledb(**to_tiledb_kwargs)
+    assert len(tiledb.Group(output_path)) == 1
     with tiledb.open(str(tmp_path / "l_0.tdb")) as A:
         if not preserve_axes:
             assert A.schema == get_schema(2220, 2967)
 
-    o = openslide.open_slide(svs_path)
-    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
+    o = openslide.open_slide(input_path)
+    with TileDBOpenSlide.from_group_uri(output_path) as t:
 
         assert t.level_count == o.level_count
         assert t.dimensions == o.dimensions
         assert t.level_dimensions == o.level_dimensions
         assert t.level_downsamples == o.level_downsamples
 
-        region = t.read_region(level=0, location=(100, 100), size=(300, 400))
+        region_kwargs = dict(level=0, location=(123, 234), size=(1328, 1896))
+
+        region = t.read_region(**region_kwargs)
         assert isinstance(region, np.ndarray)
         assert region.ndim == 3
         assert region.dtype == np.uint8
         img = PIL.Image.fromarray(region)
-        assert img.size == (300, 400)
+        assert img == o.read_region(**region_kwargs).convert("RGB")

--- a/tests/unit/test_axes.py
+++ b/tests/unit/test_axes.py
@@ -83,37 +83,37 @@ class TestAxes:
         ["YX", "ZYX", "CYX", "TYX", "CZYX", "TCYX", "TZYX", "TCZYX"],
     )
     def test_canonical_unsqueezed(self, canonical_dims):
-        a = np.random.rand(*np.random.randint(2, 20, size=len(canonical_dims)))
+        shape = np.random.randint(2, 20, size=len(canonical_dims))
         for axes in map(Axes, it.permutations(canonical_dims)):
-            assert axes.canonical(a).dims == canonical_dims
+            assert axes.canonical(shape).dims == canonical_dims
 
     def test_canonical_squeezed(self):
-        a = np.random.rand(1, 60, 40)
+        shape = (1, 60, 40)
         for s in "ZXY", "CXY", "TXY":
-            assert Axes(s).canonical(a) == Axes("YX")
+            assert Axes(s).canonical(shape) == Axes("YX")
 
-        a = np.random.rand(1, 1, 60, 40)
+        shape = (1, 1, 60, 40)
         for s in "CZXY", "TCXY", "TZXY":
-            assert Axes(s).canonical(a) == Axes("YX")
+            assert Axes(s).canonical(shape) == Axes("YX")
 
-        a = np.random.rand(3, 1, 60, 40)
-        assert Axes("CZXY").canonical(a) == Axes("CYX")
-        assert Axes("TCXY").canonical(a) == Axes("TYX")
-        assert Axes("ZTXY").canonical(a) == Axes("ZYX")
+        shape = (3, 1, 60, 40)
+        assert Axes("CZXY").canonical(shape) == Axes("CYX")
+        assert Axes("TCXY").canonical(shape) == Axes("TYX")
+        assert Axes("ZTXY").canonical(shape) == Axes("ZYX")
 
-        a = np.random.rand(1, 1, 1, 60, 40)
+        shape = (1, 1, 1, 60, 40)
         for s in "TCZXY", "TZCXY", "CZTXY":
-            assert Axes(s).canonical(a) == Axes("YX")
+            assert Axes(s).canonical(shape) == Axes("YX")
 
-        a = np.random.rand(1, 3, 1, 60, 40)
-        assert Axes("TCZXY").canonical(a) == Axes("CYX")
-        assert Axes("ZTCXY").canonical(a) == Axes("TYX")
-        assert Axes("CZTXY").canonical(a) == Axes("ZYX")
+        shape = (1, 3, 1, 60, 40)
+        assert Axes("TCZXY").canonical(shape) == Axes("CYX")
+        assert Axes("ZTCXY").canonical(shape) == Axes("TYX")
+        assert Axes("CZTXY").canonical(shape) == Axes("ZYX")
 
-        a = np.random.rand(7, 3, 1, 60, 40)
-        assert Axes("CTZXY").canonical(a) == Axes("TCYX")
-        assert Axes("ZTCXY").canonical(a) == Axes("TZYX")
-        assert Axes("ZCTXY").canonical(a) == Axes("CZYX")
+        shape = (7, 3, 1, 60, 40)
+        assert Axes("CTZXY").canonical(shape) == Axes("TCYX")
+        assert Axes("ZTCXY").canonical(shape) == Axes("TZYX")
+        assert Axes("ZCTXY").canonical(shape) == Axes("CZYX")
 
     def test_canonical_transpose_2d(self):
         a = np.random.rand(60, 40)
@@ -263,5 +263,5 @@ def assert_transpose(source, target, a, expected):
 def assert_canonical_transpose(source, a, expected):
     if not isinstance(source, Axes):
         source = Axes(source)
-    target = source.canonical(a)
+    target = source.canonical(a.shape)
     assert_transpose(source.dims, target.dims, a, expected)

--- a/tests/unit/test_tiles.py
+++ b/tests/unit/test_tiles.py
@@ -1,0 +1,56 @@
+import tiledb
+from tiledb.bioimg.converters.tiles import dim_range, iter_slices, iter_tiles
+
+domain = tiledb.Domain(
+    tiledb.Dim("X", domain=(0, 9), tile=3),
+    tiledb.Dim("Y", domain=(0, 14), tile=5),
+    tiledb.Dim("Z", domain=(0, 6), tile=4),
+    tiledb.Dim("C", domain=(0, 2), tile=3),
+)
+
+
+def test_dim_range():
+    dims = list(domain)
+    assert dim_range(dims[0]) == range(0, 10, 3)
+    assert dim_range(dims[1]) == range(0, 15, 5)
+    assert dim_range(dims[2]) == range(0, 7, 4)
+    assert dim_range(dims[3]) == range(0, 3, 3)
+
+
+def test_iter_slices():
+    assert list(iter_slices(range(0, 9, 3))) == [slice(0, 3), slice(3, 6), slice(6, 9)]
+    assert list(iter_slices(range(0, 10, 3))) == [
+        slice(0, 3),
+        slice(3, 6),
+        slice(6, 9),
+        slice(9, 10),
+    ]
+
+
+def test_iter_tiles():
+    assert list(iter_tiles(domain)) == [
+        (slice(0, 3), slice(0, 5), slice(0, 4), slice(0, 3)),
+        (slice(0, 3), slice(0, 5), slice(4, 7), slice(0, 3)),
+        (slice(0, 3), slice(5, 10), slice(0, 4), slice(0, 3)),
+        (slice(0, 3), slice(5, 10), slice(4, 7), slice(0, 3)),
+        (slice(0, 3), slice(10, 15), slice(0, 4), slice(0, 3)),
+        (slice(0, 3), slice(10, 15), slice(4, 7), slice(0, 3)),
+        (slice(3, 6), slice(0, 5), slice(0, 4), slice(0, 3)),
+        (slice(3, 6), slice(0, 5), slice(4, 7), slice(0, 3)),
+        (slice(3, 6), slice(5, 10), slice(0, 4), slice(0, 3)),
+        (slice(3, 6), slice(5, 10), slice(4, 7), slice(0, 3)),
+        (slice(3, 6), slice(10, 15), slice(0, 4), slice(0, 3)),
+        (slice(3, 6), slice(10, 15), slice(4, 7), slice(0, 3)),
+        (slice(6, 9), slice(0, 5), slice(0, 4), slice(0, 3)),
+        (slice(6, 9), slice(0, 5), slice(4, 7), slice(0, 3)),
+        (slice(6, 9), slice(5, 10), slice(0, 4), slice(0, 3)),
+        (slice(6, 9), slice(5, 10), slice(4, 7), slice(0, 3)),
+        (slice(6, 9), slice(10, 15), slice(0, 4), slice(0, 3)),
+        (slice(6, 9), slice(10, 15), slice(4, 7), slice(0, 3)),
+        (slice(9, 10), slice(0, 5), slice(0, 4), slice(0, 3)),
+        (slice(9, 10), slice(0, 5), slice(4, 7), slice(0, 3)),
+        (slice(9, 10), slice(5, 10), slice(0, 4), slice(0, 3)),
+        (slice(9, 10), slice(5, 10), slice(4, 7), slice(0, 3)),
+        (slice(9, 10), slice(10, 15), slice(0, 4), slice(0, 3)),
+        (slice(9, 10), slice(10, 15), slice(4, 7), slice(0, 3)),
+    ]

--- a/tiledb/bioimg/converters/axes.py
+++ b/tiledb/bioimg/converters/axes.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections import Counter
 from dataclasses import dataclass
 from operator import itemgetter
-from typing import Iterable, Iterator, Sequence
+from typing import Iterable, Iterator, Sequence, Tuple
 
 import numpy as np
 from pyeditdistance.distance import levenshtein
@@ -130,11 +130,11 @@ class Axes:
             raise ValueError(f"{axes.pop()!r} is not a valid Axis")
         object.__setattr__(self, "dims", dims)
 
-    def canonical(self, a: np.ndarray) -> Axes:
+    def canonical(self, shape: Tuple[int, ...]) -> Axes:
         """
-        Return a new Axes instance with the dimensions of this axes whose size in `a` are
-        greater than 1 and ordered in canonical order (TCZYX)
+        Return a new Axes instance with the dimensions of this axes whose size in `shape`
+        are greater than 1 and ordered in canonical order (TCZYX)
         """
-        assert len(self.dims) == len(a.shape)
-        dims = frozenset(dim for dim, size in zip(self.dims, a.shape) if size > 1)
+        assert len(self.dims) == len(shape)
+        dims = frozenset(dim for dim, size in zip(self.dims, shape) if size > 1)
         return Axes(dim for dim in self.CANONICAL_DIMS if dim in dims)

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -170,7 +170,7 @@ class ImageConverter:
                 if preserve_axes:
                     level_axes = axes
                 else:
-                    level_axes = axes.canonical(image)
+                    level_axes = axes.canonical(image.shape)
                     image = transpose_array(image, axes.dims, level_axes.dims)
                 # create TileDB array
                 schema = cls._get_schema(image, level_axes, tiles)

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import Any, Dict, Mapping, Tuple, cast
+from typing import Any, Dict, Mapping, Optional, Tuple, cast
 
 import numpy as np
 import tifffile
@@ -35,10 +35,11 @@ class OMETiffReader(ImageReader):
     def level_shape(self, level: int) -> Tuple[int, ...]:
         return cast(Tuple[int, ...], self._series.levels[level].shape)
 
-    def level_image(self, level: int) -> np.ndarray:
-        return self._series.levels[level].asarray()
-
-    def level_region(self, level: int, tile: Tuple[slice, ...]) -> np.ndarray:
+    def level_image(
+        self, level: int, tile: Optional[Tuple[slice, ...]] = None
+    ) -> np.ndarray:
+        if tile is None:
+            return self._series.levels[level].asarray()
         try:
             import zarr
         except ImportError:

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -38,6 +38,16 @@ class OMETiffReader(ImageReader):
     def level_image(self, level: int) -> np.ndarray:
         return self._series.levels[level].asarray()
 
+    def level_region(self, level: int, tile: Tuple[slice, ...]) -> np.ndarray:
+        try:
+            import zarr
+        except ImportError:
+            raise ImportError("zarr required for reading a Tiff tile region")
+        if not hasattr(self, "_zarr_group"):
+            store = self._series.aszarr(multiscales=True)
+            self._zarr_group = zarr.open(store, mode="r")
+        return np.asarray(self._zarr_group[level][tile])
+
     def level_metadata(self, level: int) -> Dict[str, Any]:
         if level == 0:
             omexml = self._tiff.ome_metadata

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, Tuple, cast
 
 import numpy as np
 import tifffile
@@ -29,8 +29,14 @@ class OMETiffReader(ImageReader):
     def level_count(self) -> int:
         return len(self._series.levels)
 
+    def level_dtype(self, level: int) -> np.dtype:
+        return self._series.levels[level].dtype
+
+    def level_shape(self, level: int) -> Tuple[int, ...]:
+        return cast(Tuple[int, ...], self._series.levels[level].shape)
+
     def level_image(self, level: int) -> np.ndarray:
-        return self._series.asarray(level=level)
+        return self._series.levels[level].asarray()
 
     def level_metadata(self, level: int) -> Dict[str, Any]:
         if level == 0:

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Dict, List, Mapping, Tuple, cast
+from typing import Any, Dict, List, Mapping, Optional, Tuple, cast
 
 import dask.array as da
 import numpy as np
@@ -41,11 +41,13 @@ class OMEZarrReader(ImageReader):
     def level_shape(self, level: int) -> Tuple[int, ...]:
         return cast(Tuple[int, ...], self._level_dask_array(level).shape)
 
-    def level_image(self, level: int) -> np.ndarray:
-        return np.asarray(self._level_dask_array(level))
-
-    def level_region(self, level: int, tile: Tuple[slice, ...]) -> np.ndarray:
-        return np.asarray(self._level_dask_array(level)[tile])
+    def level_image(
+        self, level: int, tile: Optional[Tuple[slice, ...]] = None
+    ) -> np.ndarray:
+        dask_array = self._level_dask_array(level)
+        if tile is not None:
+            dask_array = dask_array[tile]
+        return np.asarray(dask_array)
 
     def level_metadata(self, level: int) -> Dict[str, Any]:
         return {"json_zarray": json.dumps(self._nodes[level].zarr.zarray)}

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -44,6 +44,9 @@ class OMEZarrReader(ImageReader):
     def level_image(self, level: int) -> np.ndarray:
         return np.asarray(self._level_dask_array(level))
 
+    def level_region(self, level: int, tile: Tuple[slice, ...]) -> np.ndarray:
+        return np.asarray(self._level_dask_array(level)[tile])
+
     def level_metadata(self, level: int) -> Dict[str, Any]:
         return {"json_zarray": json.dumps(self._nodes[level].zarr.zarray)}
 

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Dict, List, Mapping, cast
+from typing import Any, Dict, List, Mapping, Tuple, cast
 
+import dask.array as da
 import numpy as np
 import zarr
 from numcodecs import Blosc
@@ -34,10 +35,14 @@ class OMEZarrReader(ImageReader):
     def level_count(self) -> int:
         return len(self._nodes)
 
+    def level_dtype(self, level: int) -> np.dtype:
+        return self._level_dask_array(level).dtype
+
+    def level_shape(self, level: int) -> Tuple[int, ...]:
+        return cast(Tuple[int, ...], self._level_dask_array(level).shape)
+
     def level_image(self, level: int) -> np.ndarray:
-        data = self._nodes[level].data
-        assert len(data) == 1
-        return np.asarray(data[0])
+        return np.asarray(self._level_dask_array(level))
 
     def level_metadata(self, level: int) -> Dict[str, Any]:
         return {"json_zarray": json.dumps(self._nodes[level].zarr.zarray)}
@@ -61,6 +66,11 @@ class OMEZarrReader(ImageReader):
         multiscales = self._root_attrs["multiscales"]
         assert len(multiscales) == 1, multiscales
         return cast(Dict[str, Any], multiscales[0])
+
+    def _level_dask_array(self, level: int) -> da.Array:
+        data = self._nodes[level].data
+        assert len(data) == 1
+        return data[0]
 
 
 class OMEZarrWriter(ImageWriter):

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, cast
+from typing import Any, Dict, Tuple, cast
 
 import numpy as np
 import openslide as osd
@@ -27,13 +27,18 @@ class OpenSlideReader(ImageReader):
     def level_count(self) -> int:
         return cast(int, self._osd.level_count)
 
-    def level_image(self, level: int) -> np.ndarray:
-        dims = self._osd.level_dimensions[level]
-        # image is in (width, height, channel) == XYC
-        image = self._osd.read_region((0, 0), level, dims).convert("RGB")
-        # np.asarray() transposes it to (height, width, channel) == YXC
+    def level_dtype(self, level: int) -> np.dtype:
+        return np.dtype(np.uint8)
+
+    def level_shape(self, level: int) -> Tuple[int, ...]:
+        width, height = self._osd.level_dimensions[level]
+        # np.asarray() of a PIL image returns a (height, width, channel) array
         # https://stackoverflow.com/questions/49084846/why-different-size-when-converting-pil-image-to-numpy-array
-        return np.asarray(image)
+        return height, width, 3
+
+    def level_image(self, level: int) -> np.ndarray:
+        size = self._osd.level_dimensions[level]
+        return np.asarray(self._osd.read_region((0, 0), level, size).convert("RGB"))
 
     def level_metadata(self, level: int) -> Dict[str, Any]:
         return {}

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -37,8 +37,18 @@ class OpenSlideReader(ImageReader):
         return height, width, 3
 
     def level_image(self, level: int) -> np.ndarray:
-        size = self._osd.level_dimensions[level]
-        return np.asarray(self._osd.read_region((0, 0), level, size).convert("RGB"))
+        return self._read_region(
+            level, location=(0, 0), size=self._osd.level_dimensions[level]
+        )
+
+    def level_region(self, level: int, tile: Tuple[slice, ...]) -> np.ndarray:
+        # tile: (Y slice, X slice, C slice)
+        y, x, _ = tile
+        return self._read_region(
+            level,
+            location=(x.start, y.start),
+            size=(x.stop - x.start, y.stop - y.start),
+        )
 
     def level_metadata(self, level: int) -> Dict[str, Any]:
         return {}
@@ -46,6 +56,11 @@ class OpenSlideReader(ImageReader):
     @property
     def group_metadata(self) -> Dict[str, Any]:
         return {}
+
+    def _read_region(
+        self, level: int, location: Tuple[int, int], size: Tuple[int, int]
+    ) -> np.ndarray:
+        return np.asarray(self._osd.read_region(location, level, size).convert("RGB"))
 
 
 class OpenSlideConverter(ImageConverter):

--- a/tiledb/bioimg/converters/tiles.py
+++ b/tiledb/bioimg/converters/tiles.py
@@ -1,0 +1,29 @@
+import itertools as it
+from typing import Iterator, Tuple
+
+import tiledb
+
+
+def iter_tiles(domain: tiledb.Domain) -> Iterator[Tuple[slice, ...]]:
+    """Generate all the non-overlapping tiles that cover the given TileDB domain."""
+    return it.product(*map(iter_slices, map(dim_range, domain)))
+
+
+def dim_range(dim: tiledb.Dim) -> range:
+    """Get the range of the given tiledb dimension with step equal to the dimension tile."""
+    return range(int(dim.domain[0]), int(dim.domain[1]) + 1, dim.tile)
+
+
+def iter_slices(r: range) -> Iterator[slice]:
+    """
+    Generate all the non-overlapping slices that cover the given range `r`,
+    with each slice having length `r.step` (except possibly the last one).
+
+    slice(r[0], r[1])
+    slice(r[1], r[2])
+    ...
+    slice(r[n-2], r[n-1])
+    slice(r[n-1], r.stop)
+    """
+    yield from it.starmap(slice, zip(r, r[1:]))
+    yield slice(r[-1], r.stop)


### PR DESCRIPTION
Add initial support for ingestion of images in chunks to limit memory requirements.

The current API is minimal: an optional boolean `chunked` parameter in `ImageConverter.to_tiledb` that when true, each image level is read in chunks, where each chunk is a single tile region in TileDB. Later this may be extended to allow chunks larger than a single tile.

To enable chunked reading, the base `ImageReader` and all its subclasses have been extended:
- `level_image` now takes an optional `tile` parameter for reading a subregion of the image
- new `level_shape` method to return the shape of the image at the given level
- new `level_dtype` method to return the `dtype` of the image at the given level

Implementation notes:
- This PR allows chunked ingestion **only** if the original axes are preserved (either due to `preserve_axes=True` or because the original axes happens to be already in canonical order). A subsequent PR will lift this constraint. 
- The chunked read support for OME-Tiff requires `zarr` since [tifffile doesn't support random access directly](https://github.com/cgohlke/tifffile/issues/134).
