### PR TITLE
Remove workaround for malformed tiff files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           pre-commit
           pytest-cov
           pytest-mock
-          boto3
 
     - name: Run pre-commit hooks
       run: pre-commit run -a

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,7 @@
 import multiprocessing
 import os
-import urllib.parse
 from pathlib import Path
 
-import boto3
 import numpy as np
 
 import tiledb
@@ -32,12 +30,4 @@ def get_schema(x_size, y_size):
 
 
 def get_path(uri):
-    if uri.startswith("s3://"):
-        s3 = boto3.client("s3")
-        parsed_uri = urllib.parse.urlparse(uri)
-        local_path = DATA_DIR / Path(parsed_uri.path).name
-        if not local_path.exists():
-            s3.download_file(parsed_uri.netloc, parsed_uri.path.lstrip("/"), local_path)
-    else:
-        local_path = DATA_DIR / uri
-    return local_path
+    return DATA_DIR / uri

--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -130,13 +130,7 @@ def compare_tiff_page_series(s1, s2):
     assert s1.dtype == s2.dtype
     np.testing.assert_array_equal(s1.asarray(), s2.asarray())
 
-    # XXX: if the tile length and/or width of the input are not a multiple of 16,
-    # we don't write tile to the output. In this case the hashes don't match
-    if s1.keyframe.tile is None or all(t % 16 == 0 for t in s1.keyframe.tile):
-        assert s1.keyframe.hash == s2.keyframe.hash
-    else:
-        assert s2.keyframe.tile is None
-
+    assert s1.keyframe.hash == s2.keyframe.hash
     assert len(s1.pages) == len(s2.pages)
     assert len(s1.levels) == len(s2.levels)
     assert s1.levels[0] is s1

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -88,16 +88,6 @@ class OMETiffWriter(ImageWriter):
         self, level: int, image: np.ndarray, metadata: Mapping[str, Any]
     ) -> None:
         write_kwargs = pickle.loads(metadata["pickled_write_kwargs"])
-        tile = write_kwargs["tile"]
-        if tile:
-            # XXX: The tile length and width must be a multiple of 16; if not ignore it
-            if (
-                len(tile) < 2
-                or tile[-1] % 16
-                or tile[-2] % 16
-                or any(i < 1 for i in tile)
-            ):
-                del write_kwargs["tile"]
         self._writer.write(image, **write_kwargs)
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:


### PR DESCRIPTION
The `CMU-1-Small-Region.ome.tiff` test file generated by [raw2ometiff](https://github.com/glencoesoftware/raw2ometiff) had [non-standard tile dimensions](https://github.com/glencoesoftware/raw2ometiff/issues/88), which required a workaround in `OMETiffWriter`  to ignore such tiles. This has since been [resolved](https://github.com/glencoesoftware/raw2ometiff/pull/89).

This PR replaces the previous  `CMU-1-Small-Region.ome.tiff` with a well-formed one and removes the workaround for malformed tiff files. While at it, the support for reading test files from S3 is also removed as it's not needed anymore. 