### PR TITLE
Replace pickle with json for OME-TIFF metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 zarr = ["ome-zarr"]
 openslide = ["openslide-python"]
-tiff = ["tifffile", "imagecodecs"]
+tiff = ["tifffile", "imagecodecs", "jsonpickle"]
 full = sorted({*zarr, *openslide, *tiff})
 
 setuptools.setup(

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -1,6 +1,6 @@
-import json
 from typing import Any, Dict, Mapping
 
+import jsonpickle as json
 import numpy as np
 import tifffile
 

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -1,4 +1,4 @@
-import pickle
+import json
 from typing import Any, Dict, Mapping
 
 import numpy as np
@@ -62,7 +62,7 @@ class OMETiffReader(ImageReader):
             resolution=keyframe.resolution,
             resolutionunit=keyframe.resolutionunit,
         )
-        return {"pickled_write_kwargs": pickle.dumps(write_kwargs)}
+        return {"json_write_kwargs": json.dumps(write_kwargs)}
 
     @property
     def group_metadata(self) -> Dict[str, Any]:
@@ -73,7 +73,7 @@ class OMETiffReader(ImageReader):
             imagej=self._tiff.is_imagej,
             ome=self._tiff.is_ome,
         )
-        return {"pickled_tiffwriter_kwargs": pickle.dumps(writer_kwargs)}
+        return {"json_tiffwriter_kwargs": json.dumps(writer_kwargs)}
 
 
 class OMETiffWriter(ImageWriter):
@@ -81,13 +81,13 @@ class OMETiffWriter(ImageWriter):
         self._output_path = output_path
 
     def write_group_metadata(self, metadata: Mapping[str, Any]) -> None:
-        tiffwriter_kwargs = pickle.loads(metadata["pickled_tiffwriter_kwargs"])
+        tiffwriter_kwargs = json.loads(metadata["json_tiffwriter_kwargs"])
         self._writer = tifffile.TiffWriter(self._output_path, **tiffwriter_kwargs)
 
     def write_level_image(
         self, level: int, image: np.ndarray, metadata: Mapping[str, Any]
     ) -> None:
-        write_kwargs = pickle.loads(metadata["pickled_write_kwargs"])
+        write_kwargs = json.loads(metadata["json_write_kwargs"])
         self._writer.write(image, **write_kwargs)
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:


### PR DESCRIPTION
Caveats: 
1. The json-deserialized metadata are not identical to the original. In particular I found two type changes:
    - Enumeration fields (e.g. `photometric`, `planarconfig`, `resolutionunit`): deserialized to integers.
    - Tuples (e.g. `extrasamples`, `tile`, `resolution`): deserialized to lists

    AFAICT neither of these differences affect the behavior of `TiffWriter.write`
2. There is no guarantee that all metadata will continue being json-serializable in the future.