### PR TITLE
Fix OpenSlideReader.level_image for chunked conversion

### DIFF
--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -172,7 +172,10 @@ class ImageConverter:
         :param tiles: A mapping from dimension name (one of 'T', 'C', 'Z', 'Y', 'X') to
             the (maximum) tile for this dimension.
         :param preserve_axes: If true, preserve the axes order of the original image.
-        :param chunked: If true, convert one image tile at a time instead of the whole image.
+        :param chunked: If true, convert one tile at a time instead of the whole image.
+            **Note**: The OpenSlideConverter may not be 100% lossless with chunked=True
+            for levels>0, even though the converted images look visually identical to the
+            original ones.
         :param max_workers: Maximum number of threads that can be used for conversion.
             Applicable only if chunked=True.
         :param register_kwargs: Cloud group registration optional args e.g namespace,


### PR DESCRIPTION
Fix `OpenSlideReader.level_image` to pass the top left pixel in the **level 0 reference frame** as `location` to [OpenSlide.read_region](https://openslide.org/api/python/#openslide.OpenSlide.read_region), instead of the current level frame (as it was assumed).

**Note**: the current fix produces visually identical images to the original ones but [it is not 100% lossless for slide level greater than 0](https://github.com/openslide/openslide/issues/256) if `chunked=True`. If this is not acceptable, a user can select `chunked=False` (the default) or replace `OpenSlideConverter` with `OMETiffConverter`.

Example with the same slide converted (a) without chunking (b) with chunking on master (c) with chunking after this fix:
![Untitled-ipynb-JupyterLab](https://user-images.githubusercontent.com/291289/210423733-277b21bf-3da4-45af-9cd5-d97faf2ee5a8.png)
