### PR TITLE
Inserting bioimg version in group metadata

### DIFF
--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -23,6 +23,8 @@ import tiledb
 from .axes import Axes, AxesMapper
 from .tiles import iter_tiles, num_tiles
 
+FMT_VERSION = 1
+
 
 class ImageReader(ABC):
     @abstractmethod
@@ -251,7 +253,8 @@ class ImageConverter:
                 group.meta.update(
                     reader.group_metadata,
                     axes=input_axes.dims,
-                    version=".".join(map(str, bioimg_version[0:3])),
+                    pckg_version=".".join(map(str, bioimg_version[0:3])),
+                    fmt_version=FMT_VERSION,
                 )
                 for uri in uris:
                     if urlparse(uri).scheme == "tiledb":

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -11,6 +11,8 @@ from urllib.parse import urlparse
 import numpy as np
 from tqdm import tqdm
 
+from ..version import version_tuple as bioimg_version
+
 try:
     from tiledb.cloud import groups
 except ImportError:
@@ -246,7 +248,11 @@ class ImageConverter:
 
             # Write group metadata
             with tiledb.Group(output_path, "w") as group:
-                group.meta.update(reader.group_metadata, axes=input_axes.dims)
+                group.meta.update(
+                    reader.group_metadata,
+                    axes=input_axes.dims,
+                    version=".".join(map(str, bioimg_version[0:3])),
+                )
                 for uri in uris:
                     if urlparse(uri).scheme == "tiledb":
                         group.add(uri, relative=False)

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 import numpy as np
 from tqdm import tqdm
 
-from ..version import version_tuple as bioimg_version
+from ..version import version
 
 try:
     from tiledb.cloud import groups
@@ -253,7 +253,7 @@ class ImageConverter:
                 group.meta.update(
                     reader.group_metadata,
                     axes=input_axes.dims,
-                    pckg_version=".".join(map(str, bioimg_version[0:3])),
+                    pkg_version=version,
                     fmt_version=FMT_VERSION,
                 )
                 for uri in uris:


### PR DESCRIPTION
This PR:

- Add an extra group metadata key for tagging version of `tiledb.bioimg`. Now the group metadata of the converted images are ```{'axes': 'YXC', 'version': '0.1.1'}```