### PR TITLE
Add TileDBOpenSlide.read_level

### DIFF
--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -38,6 +38,11 @@ def test_ome_tiff_converter(tmp_path, open_fileobj, preserve_axes):
         img = PIL.Image.fromarray(region)
         assert img.size == (300, 400)
 
+        for level in range(t.level_count):
+            region_data = t.read_region((0, 0), level, t.level_dimensions[level])
+            level_data = t.read_level(level)
+            np.testing.assert_array_equal(region_data, level_data)
+
 
 def test_ome_tiff_converter_different_dtypes(tmp_path):
     path = get_path("rand_uint16.ome.tiff")

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -40,6 +40,11 @@ def test_ome_zarr_converter(tmp_path, series_idx, preserve_axes):
             min(t.dimensions[1] - region_location[1], region_size[1]),
         )
 
+        for level in range(t.level_count):
+            region_data = t.read_region((0, 0), level, t.level_dimensions[level])
+            level_data = t.read_level(level)
+            np.testing.assert_array_equal(region_data, level_data)
+
 
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
 @pytest.mark.parametrize("preserve_axes", [False, True])

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -44,3 +44,8 @@ def test_openslide_converter(tmp_path, preserve_axes, chunked, max_workers):
         assert region.dtype == np.uint8
         img = PIL.Image.fromarray(region)
         assert img == o.read_region(**region_kwargs).convert("RGB")
+
+        for level in range(t.level_count):
+            region_data = t.read_region((0, 0), level, t.level_dimensions[level])
+            level_data = t.read_level(level)
+            np.testing.assert_array_equal(region_data, level_data)


### PR DESCRIPTION
Add a `TileDBOpenSlide.read_level` method for the (common) case of selecting a whole level image rather than a specific region with `read_region`.