### PR TITLE
Extend TileDBOpenSlide

### DIFF
--- a/examples/OMETiff-convertor-demo.ipynb
+++ b/examples/OMETiff-convertor-demo.ipynb
@@ -130,7 +130,7 @@
     }
    ],
    "source": [
-    "slide = TileDBOpenSlide.from_group_uri(dest)\n",
+    "slide = TileDBOpenSlide(dest)\n",
     "print(\"level_count:\", slide.level_count)\n",
     "print(\"dimensions:\", slide.dimensions)\n",
     "print(\"level_dimensions:\", slide.level_dimensions)\n",

--- a/examples/OMEZarr-convertor-demo.ipynb
+++ b/examples/OMEZarr-convertor-demo.ipynb
@@ -129,7 +129,7 @@
     }
    ],
    "source": [
-    "slide = TileDBOpenSlide.from_group_uri(dest)\n",
+    "slide = TileDBOpenSlide(dest)\n",
     "print(\"level_count:\", slide.level_count)\n",
     "print(\"dimensions:\", slide.dimensions)\n",
     "print(\"level_dimensions:\", slide.level_dimensions)\n",

--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -23,7 +23,7 @@ def test_ome_tiff_converter(tmp_path, open_fileobj, preserve_axes):
     else:
         OMETiffConverter.to_tiledb(input_path, output_path, preserve_axes=preserve_axes)
 
-    with TileDBOpenSlide.from_group_uri(output_path) as t:
+    with TileDBOpenSlide(output_path) as t:
         assert len(tiledb.Group(output_path)) == t.level_count == 2
 
         schemas = (get_schema(2220, 2967), get_schema(574, 768))
@@ -95,7 +95,7 @@ def test_tiledb_to_ome_tiff_group_metadata(
     tiledb_group = tiledb.Group(str(tiledb_path), mode="r")
     levels_group_meta = json.loads(tiledb_group.meta["levels"])
 
-    with TileDBOpenSlide.from_group_uri(str(tiledb_path)) as t:
+    with TileDBOpenSlide(str(tiledb_path)) as t:
         assert t.level_count == len(levels_group_meta)
         assert t.level_downsamples == tuple(
             [level["downsample_factor"] for level in levels_group_meta]
@@ -165,7 +165,7 @@ def test_ome_tiff_converter_artificial_rountrip(tmp_path, filename, dims, tiles)
 
     OMETiffConverter.to_tiledb(input_path, str(tiledb_path), tiles=tiles)
 
-    with TileDBOpenSlide.from_group_uri(str(tiledb_path)) as t:
+    with TileDBOpenSlide(str(tiledb_path)) as t:
         assert len(tiledb.Group(str(tiledb_path))) == t.level_count == 1
 
     with tiledb.open(str(tiledb_path / "l_0.tdb")) as A:

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -26,7 +26,7 @@ def test_ome_zarr_converter(tmp_path, series_idx, preserve_axes):
         if not preserve_axes:
             assert A.schema == schema
 
-    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
+    with TileDBOpenSlide(str(tmp_path)) as t:
         assert t.dimensions == t.level_dimensions[0] == schema.shape[:-3:-1]
 
         region_location = (100, 100)
@@ -106,15 +106,15 @@ def test_ome_zarr_converter_incremental(tmp_path):
     input_path = get_path("CMU-1-Small-Region.ome.zarr/0")
 
     OMEZarrConverter.to_tiledb(input_path, str(tmp_path), level_min=1)
-    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
+    with TileDBOpenSlide(str(tmp_path)) as t:
         assert len(tiledb.Group(str(tmp_path))) == t.level_count == 1
 
     OMEZarrConverter.to_tiledb(input_path, str(tmp_path), level_min=0)
-    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
+    with TileDBOpenSlide(str(tmp_path)) as t:
         assert len(tiledb.Group(str(tmp_path))) == t.level_count == 2
 
     OMEZarrConverter.to_tiledb(input_path, str(tmp_path), level_min=0)
-    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
+    with TileDBOpenSlide(str(tmp_path)) as t:
         assert len(tiledb.Group(str(tmp_path))) == t.level_count == 2
 
 
@@ -127,7 +127,7 @@ def test_ome_zarr_converter_group_meta(tmp_path, series_idx, preserve_axes):
     tiledb_group = tiledb.Group(str(tmp_path), mode="r")
     levels_group_meta = json.loads(tiledb_group.meta["levels"])
 
-    with TileDBOpenSlide.from_group_uri(str(tmp_path)) as t:
+    with TileDBOpenSlide(str(tmp_path)) as t:
         assert t.level_count == len(levels_group_meta)
         assert t.level_downsamples == tuple(
             [level["downsample_factor"] for level in levels_group_meta]

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -34,7 +34,7 @@ def test_openslide_converter(tmp_path, preserve_axes, chunked, max_workers):
     o = openslide.open_slide(input_path)
     tiledb_group = tiledb.Group(str(output_path), mode="r")
 
-    with TileDBOpenSlide.from_group_uri(output_path) as t:
+    with TileDBOpenSlide(output_path) as t:
 
         # Test group metadata
         levels_group_meta = json.loads(tiledb_group.meta["levels"])

--- a/tests/unit/test_openslide.py
+++ b/tests/unit/test_openslide.py
@@ -6,7 +6,7 @@ from tiledb.bioimg.openslide import TileDBOpenSlide
 
 
 class TestTileDBOpenSlide:
-    def test_from_group_uri(self, tmp_path):
+    def test(self, tmp_path):
         def r():
             return random.randint(64, 4096)
 
@@ -22,6 +22,6 @@ class TestTileDBOpenSlide:
                     A.meta["level"] = level
                 G.add(level_path)
 
-        with TileDBOpenSlide.from_group_uri(group_path) as t:
+        with TileDBOpenSlide(group_path) as t:
             assert t.level_count == len(level_dimensions)
             assert t.level_dimensions == tuple(level_dimensions)

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -5,15 +5,11 @@ import os
 from abc import ABC, abstractmethod
 from collections import ChainMap
 from concurrent.futures import ThreadPoolExecutor
-from operator import itemgetter
 from typing import Any, Dict, Mapping, Optional, Tuple, Type
 from urllib.parse import urlparse
 
 import numpy as np
 from tqdm import tqdm
-
-from ..version import version
-from . import DATASET_TYPE, FMT_VERSION
 
 try:
     from tiledb.cloud import groups
@@ -22,6 +18,9 @@ except ImportError:
 
 import tiledb
 
+from ..openslide import TileDBOpenSlide
+from ..version import version
+from . import DATASET_TYPE, FMT_VERSION
 from .axes import Axes, AxesMapper
 from .tiles import iter_tiles, num_tiles
 
@@ -131,28 +130,16 @@ class ImageConverter:
         if cls._ImageWriterType is None:
             raise NotImplementedError(f"{cls} does not support exporting")
 
-        # open all level arrays, keep those with level >= level_min and sort them by level
-        level_arrays = []
-        group = tiledb.Group(input_path, "r")
-        for member in group:
-            array = tiledb.open(member.uri)
-            level = array.meta.get("level", 0)
-            if level < level_min:
-                array.close()
-                continue
-            level_arrays.append((level, array))
-        level_arrays.sort(key=itemgetter(0))
-
-        with cls._ImageWriterType(output_path) as writer:
-            writer.write_group_metadata(group.meta)
-            original_axes = Axes(group.meta["axes"])
-            for level, array in level_arrays:
-                # read image and transform to the original axes
-                stored_axes = Axes(dim.name for dim in array.domain)
-                image = AxesMapper(stored_axes, original_axes).map_array(array[:])
-                # write image and close the array
-                writer.write_level_image(level, image, array.meta)
-                array.close()
+        slide = TileDBOpenSlide.from_group_uri(input_path)
+        writer = cls._ImageWriterType(output_path)
+        with slide, writer:
+            writer.write_group_metadata(slide.properties)
+            for level in slide.levels:
+                if level < level_min:
+                    continue
+                level_image = slide.read_level(level, to_original_axes=True)
+                level_metadata = slide.level_properties(level)
+                writer.write_level_image(level, level_image, level_metadata)
 
     @classmethod
     def to_tiledb(

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -130,7 +130,7 @@ class ImageConverter:
         if cls._ImageWriterType is None:
             raise NotImplementedError(f"{cls} does not support exporting")
 
-        slide = TileDBOpenSlide.from_group_uri(input_path)
+        slide = TileDBOpenSlide(input_path)
         writer = cls._ImageWriterType(output_path)
         with slide, writer:
             writer.write_group_metadata(slide.properties)

--- a/tiledb/bioimg/openslide.py
+++ b/tiledb/bioimg/openslide.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any, Iterator, Mapping, Sequence, Tuple, Union
 
 import numpy as np
@@ -17,6 +18,11 @@ from .converters.axes import Axes, AxesMapper
 class TileDBOpenSlide:
     @classmethod
     def from_group_uri(cls, uri: str) -> TileDBOpenSlide:
+        warnings.warn(
+            "This method is deprecated, please use TileDBOpenSlide() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return cls(uri)
 
     def __init__(self, uri: str):


### PR DESCRIPTION
This PR:
- extends the `TileDBOpenSlide` with a few new accessors:
  - new properties: `levels`, `properties`, `original_axes`
  - new method: `level_properties`
  - new optional `to_original_axes` parameter for `read_level`/`read_level_dask`
- rewrites `ImageConverter.from_tiledb` to use the extended `TileDBOpenSlide` instead of raw tiledb-py to access the image data and metadata.
- deprecates  `TileDBOpenSlide.from_group_uri(uri)` in favor of `TileDBOpenSlide(uri)`.
