### PR TITLE
Allow custom compressor 

### DIFF
--- a/tiledb/bioimg/converters/axes.py
+++ b/tiledb/bioimg/converters/axes.py
@@ -102,7 +102,14 @@ class Axes:
 
 class AxesMapper:
     def __init__(self, source: Axes, target: Axes):
+        self._source = source
+        self._target = target
         self._transforms = tuple(_iter_transforms(source.dims, target.dims))
+
+    @property
+    def inverted(self) -> AxesMapper:
+        """Return the inverted axes mapper, i.e. one that maps target to source"""
+        return AxesMapper(self._target, self._source)
 
     def map_array(self, a: np.ndarray) -> np.ndarray:
         """Transform a Numpy array from the source axes `s` to the target axes `t`.


### PR DESCRIPTION
First PR (out of 2) for webP support:
- Introduce optional `compressor` parameter in `ImageConverter.to_tiledb`. Defaults to the currently hardcoded value (`tiledb.ZstdFilter(level=0)`).
- Refactor code to pave the way for adding WebP. In particular, add a `get_pixel_depth()` function (better name suggestions are welcome) that returns the number of values encoded for each pixel. For non-webp compressors (i.e. this PR), this is always 1. For webP, the pixel depth will be determined by the selected colorspace format as described [here](https://github.com/TileDB-Inc/TileDB/blob/master/format_spec/filters/webp.md).
- Mostly unrelated but useful change: move the bulk of the `TileDBOpenSlide` functionality to a new `TileDBOpenSlideLevel` class and make the former essentially a sequence of the latter.