### PR TITLE
AxesMapper refactoring

### DIFF
--- a/tests/unit/test_axes.py
+++ b/tests/unit/test_axes.py
@@ -6,20 +6,20 @@ import pytest
 from tiledb.bioimg.converters.axes import Axes, Move, Squeeze, Swap, Unsqueeze
 
 
-class TestTransforms:
+class TestAxesMappers:
     @pytest.mark.parametrize(
         "s,i,j", [(b"ADCBE", 1, 3), (b"DBCAE", 3, 0), (b"ACBDE", 2, 1)]
     )
     def test_swap(self, s, i, j):
-        transform = Swap(i, j)
+        axes_mapper = Swap(i, j)
         b = bytearray(s)
-        assert transform.transform_sequence(b) is None
+        assert axes_mapper.transform_sequence(b) is None
         assert b == b"ABCDE"
 
     def test_swap_array(self):
-        transform = Swap(1, 3)
+        axes_mapper = Swap(1, 3)
         a = np.empty((5, 4, 8, 3, 6))
-        np.testing.assert_array_equal(transform.map_array(a), np.swapaxes(a, 1, 3))
+        np.testing.assert_array_equal(axes_mapper.map_array(a), np.swapaxes(a, 1, 3))
 
     @pytest.mark.parametrize(
         "s,i,j",
@@ -33,15 +33,15 @@ class TestTransforms:
         ],
     )
     def test_move(self, s, i, j):
-        transform = Move(i, j)
+        axes_mapper = Move(i, j)
         b = bytearray(s)
-        assert transform.transform_sequence(b) is None
+        assert axes_mapper.transform_sequence(b) is None
         assert b == b"ABCDE"
 
     def test_move_array(self):
-        transform = Move(1, 3)
+        axes_mapper = Move(1, 3)
         a = np.empty((5, 4, 8, 3, 6))
-        np.testing.assert_array_equal(transform.map_array(a), np.moveaxis(a, 1, 3))
+        np.testing.assert_array_equal(axes_mapper.map_array(a), np.moveaxis(a, 1, 3))
 
     @pytest.mark.parametrize(
         "s,idxs",
@@ -53,15 +53,15 @@ class TestTransforms:
         ],
     )
     def test_squeeze(self, s, idxs):
-        transform = Squeeze(idxs)
+        axes_mapper = Squeeze(idxs)
         b = bytearray(s)
-        assert transform.transform_sequence(b) is None
+        assert axes_mapper.transform_sequence(b) is None
         assert b == b"ABC"
 
     def test_squeeze_array(self):
-        transform = Squeeze((1, 3))
+        axes_mapper = Squeeze((1, 3))
         a = np.empty((5, 1, 8, 1, 6))
-        np.testing.assert_array_equal(transform.map_array(a), np.squeeze(a, (1, 3)))
+        np.testing.assert_array_equal(axes_mapper.map_array(a), np.squeeze(a, (1, 3)))
 
     @pytest.mark.parametrize(
         "s,idxs,t",
@@ -74,15 +74,17 @@ class TestTransforms:
         ],
     )
     def test_unsqueeze(self, s, idxs, t):
-        transform = Unsqueeze(idxs)
+        axes_mapper = Unsqueeze(idxs)
         b = bytearray(s)
-        assert transform.transform_sequence(b, fill_value=ord("_")) is None
+        assert axes_mapper.transform_sequence(b, fill_value=ord("_")) is None
         assert b == t
 
     def test_unsqueeze_array(self):
-        transform = Unsqueeze((1, 3))
+        axes_mapper = Unsqueeze((1, 3))
         a = np.empty((5, 8, 6))
-        np.testing.assert_array_equal(transform.map_array(a), np.expand_dims(a, (1, 3)))
+        np.testing.assert_array_equal(
+            axes_mapper.map_array(a), np.expand_dims(a, (1, 3))
+        )
 
 
 class TestAxes:
@@ -143,7 +145,7 @@ class TestAxes:
         assert Axes("ZCTXY").canonical(shape) == Axes("CZYX")
 
 
-class TestAxesMapper:
+class TestCompositeAxesMapper:
     def test_canonical_transform_2d(self):
         a = np.random.rand(60, 40)
         assert_canonical_transform("YX", a, a)

--- a/tests/unit/test_axes.py
+++ b/tests/unit/test_axes.py
@@ -3,14 +3,7 @@ import itertools as it
 import numpy as np
 import pytest
 
-from tiledb.bioimg.converters.axes import (
-    Axes,
-    AxesMapper,
-    Move,
-    Squeeze,
-    Swap,
-    Unsqueeze,
-)
+from tiledb.bioimg.converters.axes import Axes, Move, Squeeze, Swap, Unsqueeze
 
 
 class TestTransforms:
@@ -292,7 +285,7 @@ class TestAxesMapper:
 
 
 def assert_transform(source, target, a, expected):
-    axes_mapper = AxesMapper(Axes(source), Axes(target))
+    axes_mapper = Axes(source).mapper(Axes(target))
     assert axes_mapper.map_shape(a.shape) == expected.shape
     np.testing.assert_array_equal(axes_mapper.map_array(a), expected)
 
@@ -300,6 +293,6 @@ def assert_transform(source, target, a, expected):
 def assert_canonical_transform(source, a, expected):
     source = Axes(source)
     target = source.canonical(a.shape)
-    axes_mapper = AxesMapper(source, target)
+    axes_mapper = source.mapper(target)
     assert axes_mapper.map_shape(a.shape) == expected.shape
     np.testing.assert_array_equal(axes_mapper.map_array(a), expected)

--- a/tests/unit/test_axes.py
+++ b/tests/unit/test_axes.py
@@ -13,7 +13,7 @@ class TestTransforms:
     def test_swap(self, s, i, j):
         transform = Swap(i, j)
         b = bytearray(s)
-        assert transform(b) is None
+        assert transform.transform_sequence(b) is None
         assert b == b"ABCDE"
 
     def test_swap_array(self):
@@ -35,7 +35,7 @@ class TestTransforms:
     def test_move(self, s, i, j):
         transform = Move(i, j)
         b = bytearray(s)
-        assert transform(b) is None
+        assert transform.transform_sequence(b) is None
         assert b == b"ABCDE"
 
     def test_move_array(self):
@@ -55,7 +55,7 @@ class TestTransforms:
     def test_squeeze(self, s, idxs):
         transform = Squeeze(idxs)
         b = bytearray(s)
-        assert transform(b) is None
+        assert transform.transform_sequence(b) is None
         assert b == b"ABC"
 
     def test_squeeze_array(self):
@@ -76,7 +76,7 @@ class TestTransforms:
     def test_unsqueeze(self, s, idxs, t):
         transform = Unsqueeze(idxs)
         b = bytearray(s)
-        assert transform(b, fill_value=ord("_")) is None
+        assert transform.transform_sequence(b, fill_value=ord("_")) is None
         assert b == t
 
     def test_unsqueeze_array(self):

--- a/tiledb/bioimg/converters/axes.py
+++ b/tiledb/bioimg/converters/axes.py
@@ -188,17 +188,18 @@ class Axes:
         dims = frozenset(dim for dim, size in zip(self.dims, shape) if size > 1)
         return Axes(dim for dim in self.CANONICAL_DIMS if dim in dims)
 
+    def mapper(self, other: Axes) -> AxesMapper:
+        return AxesMapper(_iter_transforms(self.dims, other.dims))
+
 
 class AxesMapper:
-    def __init__(self, source: Axes, target: Axes):
-        self._transforms = list(_iter_transforms(source.dims, target.dims))
+    def __init__(self, transforms: Iterable[Transform]):
+        self._transforms = tuple(transforms)
 
     @property
     def inverse(self) -> AxesMapper:
         """Return the inverse axes mapper, i.e. one that maps target to source"""
-        inverse = self.__new__(AxesMapper)
-        inverse._transforms = list(t.inverse for t in reversed(self._transforms))
-        return inverse
+        return AxesMapper(t.inverse for t in reversed(self._transforms))
 
     def map_array(self, a: np.ndarray) -> np.ndarray:
         """Transform a Numpy array from the source axes `s` to the target axes `t`.

--- a/tiledb/bioimg/converters/axes.py
+++ b/tiledb/bioimg/converters/axes.py
@@ -189,7 +189,17 @@ class Axes:
         return Axes(dim for dim in self.CANONICAL_DIMS if dim in dims)
 
     def mapper(self, other: Axes) -> AxesMapper:
+        """Return an AxesMapper from this axes to other"""
         return AxesMapper(_iter_transforms(self.dims, other.dims))
+
+    def webp_mapper(self, num_channels: int) -> AxesMapper:
+        """Return an AxesMapper from this 3D axes (YXC or a permutation) to 2D (YX)"""
+
+        def gen_transforms() -> Iterator[Transform]:
+            yield from _iter_transforms(self.dims, "YXC")
+            yield YXC_TO_YX(num_channels)
+
+        return AxesMapper(gen_transforms())
 
 
 class AxesMapper:

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -27,7 +27,6 @@ from ..version import version as PKG_VERSION
 from . import DATASET_TYPE, FMT_VERSION
 from .axes import Axes, AxesMapper
 from .tiles import iter_tiles, num_tiles
-from .webp import ToWebPAxesMapper
 
 
 class ImageReader(ABC):
@@ -259,7 +258,7 @@ class ImageConverter:
                     dim_names = tuple(target_axes.dims)
                 else:
                     max_tiles["X"] *= pixel_depth
-                    axes_mapper = ToWebPAxesMapper(source_axes, pixel_depth)
+                    axes_mapper = source_axes.webp_mapper(pixel_depth)
                     dim_names = ("Y", "X")
 
                 # create TileDB schema

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -255,7 +255,7 @@ class ImageConverter:
                         target_axes = source_axes
                     else:
                         target_axes = source_axes.canonical(source_shape)
-                    axes_mapper = AxesMapper(source_axes, target_axes)
+                    axes_mapper = source_axes.mapper(target_axes)
                     dim_names = tuple(target_axes.dims)
                 else:
                     max_tiles["X"] *= pixel_depth

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -392,7 +392,7 @@ def _convert_level_to_tiledb(
 ) -> None:
     out_array.meta.update(reader.level_metadata(level), level=level)
     if chunked or max_workers:
-        inv_axes_mapper = axes_mapper.inverted
+        inv_axes_mapper = axes_mapper.inverse
 
         def tile_to_tiledb(level_tile: Tuple[slice, ...]) -> None:
             source_tile = inv_axes_mapper.map_tile(level_tile)

--- a/tiledb/bioimg/converters/webp.py
+++ b/tiledb/bioimg/converters/webp.py
@@ -1,9 +1,8 @@
 from .axes import YXC_TO_YX, Axes, AxesMapper
 
 
-class ToWebPAxesMapper(AxesMapper):
+def ToWebPAxesMapper(source: Axes, c_size: int) -> AxesMapper:
     """Mapper from 3D axes (YXC or permutations thereof) to 2D (YX)"""
-
-    def __init__(self, source: Axes, c_size: int):
-        super().__init__(source, target=Axes("YXC"))
-        self._transforms.append(YXC_TO_YX(c_size))
+    mapper = source.mapper(Axes("YXC"))
+    mapper._transforms += (YXC_TO_YX(c_size),)
+    return mapper

--- a/tiledb/bioimg/converters/webp.py
+++ b/tiledb/bioimg/converters/webp.py
@@ -1,4 +1,4 @@
-from .axes import YX_TO_YXC, YXC_TO_YX, Axes, AxesMapper
+from .axes import YXC_TO_YX, Axes, AxesMapper
 
 
 class ToWebPAxesMapper(AxesMapper):
@@ -7,11 +7,3 @@ class ToWebPAxesMapper(AxesMapper):
     def __init__(self, source: Axes, c_size: int):
         super().__init__(source, target=Axes("YXC"))
         self._transforms.append(YXC_TO_YX(c_size))
-
-
-class FromWebPAxesMapper(AxesMapper):
-    """Mapper from 2D axes (YX) to 3D (YXC or permutations thereof)"""
-
-    def __init__(self, target: Axes, c_size: int):
-        super().__init__(Axes("YXC"), target)
-        self._transforms.insert(0, YX_TO_YXC(c_size))

--- a/tiledb/bioimg/converters/webp.py
+++ b/tiledb/bioimg/converters/webp.py
@@ -1,8 +1,0 @@
-from .axes import YXC_TO_YX, Axes, AxesMapper
-
-
-def ToWebPAxesMapper(source: Axes, c_size: int) -> AxesMapper:
-    """Mapper from 3D axes (YXC or permutations thereof) to 2D (YX)"""
-    mapper = source.mapper(Axes("YXC"))
-    mapper._transforms += (YXC_TO_YX(c_size),)
-    return mapper

--- a/tiledb/bioimg/converters/webp.py
+++ b/tiledb/bioimg/converters/webp.py
@@ -10,10 +10,11 @@ class ToWebPAxesMapper(AxesMapper):
 
     def __init__(self, source: Axes, c_size: int):
         super().__init__(source, target=Axes("YXC"))
+        self._source = source
         self._c_size = c_size
 
     @property
-    def inverted(self) -> AxesMapper:
+    def inverse(self) -> AxesMapper:
         return FromWebPAxesMapper(self._source, self._c_size)
 
     def map_array(self, a: np.ndarray) -> np.ndarray:
@@ -44,10 +45,11 @@ class FromWebPAxesMapper(AxesMapper):
 
     def __init__(self, target: Axes, c_size: int):
         super().__init__(Axes("YXC"), target)
+        self._target = target
         self._c_size = c_size
 
     @property
-    def inverted(self) -> AxesMapper:
+    def inverse(self) -> AxesMapper:
         return ToWebPAxesMapper(self._target, self._c_size)
 
     def map_array(self, a: np.ndarray) -> np.ndarray:

--- a/tiledb/bioimg/converters/webp.py
+++ b/tiledb/bioimg/converters/webp.py
@@ -1,8 +1,4 @@
-from typing import Tuple, TypeVar
-
-import numpy as np
-
-from .axes import Axes, AxesMapper
+from .axes import YX_TO_YXC, YXC_TO_YX, Axes, AxesMapper
 
 
 class ToWebPAxesMapper(AxesMapper):
@@ -10,34 +6,7 @@ class ToWebPAxesMapper(AxesMapper):
 
     def __init__(self, source: Axes, c_size: int):
         super().__init__(source, target=Axes("YXC"))
-        self._source = source
-        self._c_size = c_size
-
-    @property
-    def inverse(self) -> AxesMapper:
-        return FromWebPAxesMapper(self._source, self._c_size)
-
-    def map_array(self, a: np.ndarray) -> np.ndarray:
-        s = self.map_shape(a.shape)
-        return super().map_array(a).reshape(s)
-
-    def map_shape(self, shape: Tuple[int, ...]) -> Tuple[int, ...]:
-        y, x, c = super().map_shape(shape)
-        if c != self._c_size:
-            raise ValueError(
-                f"{self._c_size} channels expected, {c} given in input_shape: {shape}"
-            )
-        return y, x * c
-
-    def map_tile(self, tile: Tuple[slice, ...]) -> Tuple[slice, ...]:
-        y, x, c = super().map_tile(tile)
-        if c != slice(None):
-            raise ValueError(f"Only full slice for C dimension is supported, {c} given")
-        xc = slice(x.start * self._c_size, x.stop * self._c_size)
-        return y, xc
-
-
-Idx = TypeVar("Idx", int, slice)
+        self._transforms.append(YXC_TO_YX(c_size))
 
 
 class FromWebPAxesMapper(AxesMapper):
@@ -45,27 +14,4 @@ class FromWebPAxesMapper(AxesMapper):
 
     def __init__(self, target: Axes, c_size: int):
         super().__init__(Axes("YXC"), target)
-        self._target = target
-        self._c_size = c_size
-
-    @property
-    def inverse(self) -> AxesMapper:
-        return ToWebPAxesMapper(self._target, self._c_size)
-
-    def map_array(self, a: np.ndarray) -> np.ndarray:
-        return super().map_array(a.reshape(self._to_yxc(a.shape)))
-
-    def map_shape(self, shape: Tuple[int, ...]) -> Tuple[int, ...]:
-        return super().map_shape(self._to_yxc(shape))
-
-    def map_tile(self, tile: Tuple[slice, ...]) -> Tuple[slice, ...]:
-        return super().map_tile(self._to_yxc(tile))
-
-    def _to_yxc(self, shape_or_tile: Tuple[Idx, ...]) -> Tuple[Idx, ...]:
-        c = self._c_size
-        y, xc = shape_or_tile
-        if isinstance(xc, int):
-            assert not isinstance(y, slice)  # assertion added to appease mypy
-            return y, xc // c, c
-        else:
-            return y, slice(xc.start // c, xc.stop // c), slice(None)
+        self._transforms.insert(0, YX_TO_YXC(c_size))

--- a/tiledb/bioimg/openslide.py
+++ b/tiledb/bioimg/openslide.py
@@ -14,7 +14,6 @@ except ImportError:
 import tiledb
 
 from .converters.axes import Axes
-from .converters.webp import ToWebPAxesMapper
 
 
 class TileDBOpenSlide:
@@ -188,7 +187,7 @@ class TileDBOpenSlideLevel:
             x = dim_slice.get("X")
             if x is not None:
                 dim_slice["X"] = slice(x.start * pixel_depth, x.stop * pixel_depth)
-            axes_mapper = ToWebPAxesMapper(axes, pixel_depth)
+            axes_mapper = axes.webp_mapper(pixel_depth)
 
         array = da.from_tiledb(self._tdb) if to_dask else self._tdb
         selector = tuple(dim_slice.get(dim, slice(None)) for dim in dims)

--- a/tiledb/bioimg/openslide.py
+++ b/tiledb/bioimg/openslide.py
@@ -14,7 +14,7 @@ except ImportError:
 import tiledb
 
 from .converters.axes import Axes, AxesMapper
-from .converters.webp import FromWebPAxesMapper
+from .converters.webp import ToWebPAxesMapper
 
 
 class TileDBOpenSlide:
@@ -188,7 +188,7 @@ class TileDBOpenSlideLevel:
             x = dim_slice.get("X")
             if x is not None:
                 dim_slice["X"] = slice(x.start * pixel_depth, x.stop * pixel_depth)
-            axes_mapper = FromWebPAxesMapper(axes, pixel_depth)
+            axes_mapper = ToWebPAxesMapper(axes, pixel_depth).inverse
 
         array = da.from_tiledb(self._tdb) if to_dask else self._tdb
         selector = tuple(dim_slice.get(dim, slice(None)) for dim in dims)

--- a/tiledb/bioimg/openslide.py
+++ b/tiledb/bioimg/openslide.py
@@ -13,7 +13,7 @@ except ImportError:
 
 import tiledb
 
-from .converters.axes import Axes, AxesMapper
+from .converters.axes import Axes
 from .converters.webp import ToWebPAxesMapper
 
 
@@ -183,16 +183,16 @@ class TileDBOpenSlideLevel:
         dims = tuple(dim.name for dim in self._tdb.domain)
         pixel_depth = self._pixel_depth
         if pixel_depth == 1:
-            axes_mapper = AxesMapper(Axes(dims), axes)
+            axes_mapper = axes.mapper(Axes(dims))
         else:
             x = dim_slice.get("X")
             if x is not None:
                 dim_slice["X"] = slice(x.start * pixel_depth, x.stop * pixel_depth)
-            axes_mapper = ToWebPAxesMapper(axes, pixel_depth).inverse
+            axes_mapper = ToWebPAxesMapper(axes, pixel_depth)
 
         array = da.from_tiledb(self._tdb) if to_dask else self._tdb
         selector = tuple(dim_slice.get(dim, slice(None)) for dim in dims)
-        return axes_mapper.map_array(array[selector])
+        return axes_mapper.inverse.map_array(array[selector])
 
     def close(self) -> None:
         self._tdb.close()


### PR DESCRIPTION
- Replace the `ToWebPAxesMapper` and `FromWebPAxesMapper` subclasses of `AxesMapper` (introduced in https://github.com/TileDB-Inc/TileDB-BioImaging/pull/65) with:
  1. `YXC_TO_YX`  and `YX_TO_YXC` subclasses of `Transform`
  2. `Axes.webp_mapper` method to create the webp mapper from a given source axis.
- Unify the similar but separate APIs of `Transform` and `AxesMapper` and make the latter yet another subclass of the former.
- Rename `AxesMapper` to `CompositeAxesMapper`
- Rename `Transform` to `AxesMapper`
  