### PR TITLE
Allow passing ImageReader to `ImageConverter.to_tiledb`

### DIFF
--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -8,6 +8,7 @@ import zarr
 import tiledb
 from tests import assert_image_similarity, get_path, get_schema
 from tiledb.bioimg.converters import DATASET_TYPE, FMT_VERSION
+from tiledb.bioimg.converters.ome_tiff import OMETiffReader
 from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter, OMEZarrReader
 from tiledb.bioimg.helpers import open_bioimg
 from tiledb.bioimg.openslide import TileDBOpenSlide
@@ -18,8 +19,26 @@ schemas = (get_schema(2220, 2967), get_schema(387, 463), get_schema(1280, 431))
 
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
 @pytest.mark.parametrize("preserve_axes", [False, True])
-def test_ome_zarr_converter_reader_arg(tmp_path, series_idx, preserve_axes):
+def test_ome_zarr_converter_source_reader_exception(
+    tmp_path, series_idx, preserve_axes
+):
+    tiff_path = get_path("CMU-1-Small-Region.ome.tiff")
+    output_reader = tmp_path / "to_tiledb_reader"
+
+    with pytest.raises(ValueError) as excinfo:
+        OMEZarrConverter.to_tiledb(
+            OMETiffReader(tiff_path), str(output_reader), preserve_axes=preserve_axes
+        )
+    assert "reader should match converter" in str(excinfo)
+
+
+@pytest.mark.parametrize("series_idx", [0, 1, 2])
+@pytest.mark.parametrize("preserve_axes", [False, True])
+def test_ome_zarr_converter_reader_source_consistent_output(
+    tmp_path, series_idx, preserve_axes
+):
     input_path = get_path("CMU-1-Small-Region.ome.zarr") / str(series_idx)
+
     output_path = tmp_path / "to_tiledb_path"
     output_reader = tmp_path / "to_tiledb_reader"
 

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -31,7 +31,7 @@ from ..helpers import (
 from ..openslide import TileDBOpenSlide
 from ..version import version as PKG_VERSION
 from . import DATASET_TYPE, FMT_VERSION
-from .axes import Axes, AxesMapper
+from .axes import Axes
 from .tiles import iter_tiles, num_tiles
 
 
@@ -239,62 +239,35 @@ class ImageConverter:
                     quality=compressor.quality,
                     lossless=compressor.lossless,
                 )
-            pixel_depth = get_pixel_depth(compressor)
 
+            convert_kwargs = dict(
+                reader=reader,
+                rw_group=rw_group,
+                max_tiles=max_tiles,
+                preserve_axes=preserve_axes,
+                chunked=chunked,
+                max_workers=max_workers,
+                compressor=compressor,
+            )
             if pyramid_kwargs is not None:
-                level_max = level_min + 1
-                if reader.level_count > level_max:
+                if level_min < reader.level_count - 1:
                     warnings.warn(
                         f"The image contains multiple levels but only level {level_min} "
                         "will be considered for generating the image pyramid"
                     )
-            else:
-                level_max = reader.level_count
-
-            source_axes = reader.axes
-            for level in range(level_min, level_max):
-                # create mapper from source to target axes
-                source_shape = reader.level_shape(level)
-                if pixel_depth == 1:
-                    if preserve_axes:
-                        target_axes = source_axes
-                    else:
-                        target_axes = source_axes.canonical(source_shape)
-                    axes_mapper = source_axes.mapper(target_axes)
-                    dim_names = tuple(target_axes.dims)
-                else:
-                    max_tiles["X"] *= pixel_depth
-                    axes_mapper = source_axes.webp_mapper(pixel_depth)
-                    dim_names = ("Y", "X")
-
-                # create TileDB schema
-                dim_shape = axes_mapper.map_shape(source_shape)
-                attr_dtype = reader.level_dtype(level)
-                schema = get_schema(
-                    dim_names, dim_shape, max_tiles, attr_dtype, compressor
-                )
-
-                # get or create TileDB array uri
-                uri, created = rw_group.get_or_create(f"l_{level}.tdb", schema)
-                if not created:
-                    continue
-
-                # write image and metadata to TileDB array
-                with open_bioimg(uri, "w") as out_array:
-                    _convert_level_to_tiledb(
-                        reader, level, out_array, axes_mapper, chunked, max_workers
-                    )
-
-            if pyramid_kwargs is not None:
+                uri = _convert_level_to_tiledb(level_min, **convert_kwargs)
                 create_image_pyramid(
                     rw_group, uri, level_min, max_tiles, compressor, pyramid_kwargs
                 )
+            else:
+                for level in range(level_min, reader.level_count):
+                    _convert_level_to_tiledb(level, **convert_kwargs)
 
         with rw_group:
             rw_group.w_group.meta.update(
                 reader.group_metadata,
-                axes=source_axes.dims,
-                pixel_depth=pixel_depth,
+                axes=reader.axes.dims,
+                pixel_depth=get_pixel_depth(compressor),
                 pkg_version=PKG_VERSION,
                 fmt_version=FMT_VERSION,
                 dataset_type=DATASET_TYPE,
@@ -309,33 +282,63 @@ class ImageConverter:
 
 
 def _convert_level_to_tiledb(
-    reader: ImageReader,
     level: int,
-    out_array: tiledb.Array,
-    axes_mapper: AxesMapper,
+    *,
+    reader: ImageReader,
+    rw_group: ReadWriteGroup,
+    max_tiles: Dict[str, int],
+    preserve_axes: bool,
     chunked: bool,
     max_workers: int,
-) -> None:
-    out_array.meta.update(reader.level_metadata(level), level=level)
-    if chunked or max_workers:
-        inv_axes_mapper = axes_mapper.inverse
-
-        def tile_to_tiledb(level_tile: Tuple[slice, ...]) -> None:
-            source_tile = inv_axes_mapper.map_tile(level_tile)
-            image = reader.level_image(level, source_tile)
-            out_array[level_tile] = axes_mapper.map_array(image)
-
-        ex = ThreadPoolExecutor(max_workers) if max_workers else None
-        mapper = getattr(ex, "map", map)
-        for _ in tqdm(
-            mapper(tile_to_tiledb, iter_tiles(out_array.domain)),
-            desc=f"Ingesting level {level}",
-            total=num_tiles(out_array.domain),
-            unit="tiles",
-        ):
-            pass
-        if ex:
-            ex.shutdown()
+    compressor: tiledb.Filter,
+) -> str:
+    # create mapper from source to target axes
+    source_axes = reader.axes
+    source_shape = reader.level_shape(level)
+    pixel_depth = get_pixel_depth(compressor)
+    if pixel_depth == 1:
+        if preserve_axes:
+            target_axes = source_axes
+        else:
+            target_axes = source_axes.canonical(source_shape)
+        axes_mapper = source_axes.mapper(target_axes)
+        dim_names = tuple(target_axes.dims)
     else:
-        image = reader.level_image(level)
-        out_array[:] = axes_mapper.map_array(image)
+        max_tiles["X"] *= pixel_depth
+        axes_mapper = source_axes.webp_mapper(pixel_depth)
+        dim_names = ("Y", "X")
+
+    # create TileDB schema
+    dim_shape = axes_mapper.map_shape(source_shape)
+    attr_dtype = reader.level_dtype(level)
+    schema = get_schema(dim_names, dim_shape, max_tiles, attr_dtype, compressor)
+
+    # get or create TileDB array uri
+    uri, created = rw_group.get_or_create(f"l_{level}.tdb", schema)
+    if created:
+        # write image and metadata to TileDB array
+        with open_bioimg(uri, "w") as out_array:
+            out_array.meta.update(reader.level_metadata(level), level=level)
+            if chunked or max_workers:
+                inv_axes_mapper = axes_mapper.inverse
+
+                def tile_to_tiledb(level_tile: Tuple[slice, ...]) -> None:
+                    source_tile = inv_axes_mapper.map_tile(level_tile)
+                    image = reader.level_image(level, source_tile)
+                    out_array[level_tile] = axes_mapper.map_array(image)
+
+                ex = ThreadPoolExecutor(max_workers) if max_workers else None
+                mapper = getattr(ex, "map", map)
+                for _ in tqdm(
+                    mapper(tile_to_tiledb, iter_tiles(out_array.domain)),
+                    desc=f"Ingesting level {level}",
+                    total=num_tiles(out_array.domain),
+                    unit="tiles",
+                ):
+                    pass
+                if ex:
+                    ex.shutdown()
+            else:
+                image = reader.level_image(level)
+                out_array[:] = axes_mapper.map_array(image)
+    return uri

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -164,7 +164,7 @@ class ImageConverter:
     @classmethod
     def to_tiledb(
         cls,
-        input_path: Union[str, ImageReader],
+        source: Union[str, ImageReader],
         output_path: str,
         *,
         level_min: int = 0,
@@ -180,7 +180,7 @@ class ImageConverter:
         """
         Convert an image to a TileDB Group of Arrays, one per level.
 
-        :param input_path: path to the input image
+        :param source: path to the input image or ImageReader object
         :param output_path: path to the TileDB group of arrays
         :param level_min: minimum level of the image to be converted. By default set to 0
             to convert all levels.
@@ -213,10 +213,12 @@ class ImageConverter:
                 chunked downsampling. If None, it will default to the number of processors
                 on the machine, multiplied by 5.
         """
-        if isinstance(input_path, ImageReader):
-            reader = input_path
+        if isinstance(source, ImageReader):
+            if cls._ImageReaderType != source.__class__:
+                raise ValueError("Image reader should match converter on source format")
+            reader = source
         elif cls._ImageReaderType is not None:
-            reader = cls._ImageReaderType(input_path, **reader_kwargs)
+            reader = cls._ImageReaderType(source, **reader_kwargs)
         else:
             raise NotImplementedError(f"{cls} does not support importing")
 

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -68,11 +68,8 @@ class ReadWriteGroup:
         return uri, create
 
 
-def open_bioimg(
-    uri: str, *args: Optional[Any], **kwargs: Optional[Any]
-) -> tiledb.Array:
-    attr = None if "w" in args or kwargs.get("mode") == "w" else ATTR_NAME
-    return tiledb.open(uri, attr=attr, *args, **kwargs)
+def open_bioimg(uri: str, mode: str = "r") -> tiledb.Array:
+    return tiledb.open(uri, mode=mode, attr=ATTR_NAME if mode == "r" else None)
 
 
 def get_schema(

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterator, Mapping, Optional, Tuple
+from typing import Any, Iterator, Mapping, Tuple
 from urllib.parse import urljoin, urlparse
 
 import numpy as np


### PR DESCRIPTION
Allow passing an existing `ImageReader` instance as `input_path` to `ImageConverter.to_tiledb`. 
Uses cases:
  - Not having to create a `FooConverter` class for every `FooReader`; a user can call `ImageConverter.to_tiledb(FooReader(...), ...)` instead.
  - In case one needs to convert the same input more than once (e.g. to both lossless and lossy output) and creating a `FooReader` is expensive, create only one instance and pass it to multiple `to_tiledb` calls.

Also some more `ImageConverter.to_tiledb` refactoring  while at it.

**Breaking Backwards Compatibility**: Breaking API `to_tiledb` with `source` argument instead of `input_path`