### PR TITLE
Excluding tests and docs from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-prune tests/
-prune docs/

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import setuptools
-from setuptools import find_namespace_packages
 
 zarr = ["ome-zarr"]
 openslide = ["openslide-python"]
@@ -8,7 +7,6 @@ cloud = ["tiledb-cloud"]
 
 full = sorted({*zarr, *openslide, *tiff, *cloud})
 setuptools.setup(
-    packages=find_namespace_packages(exclude=["tests*", "docs*"]),
     setup_requires=["setuptools_scm"],
     use_scm_version={
         "version_scheme": "guess-next-dev",


### PR DESCRIPTION
This PR:

- Fixes the `setup.py` and `setup.cfg` files s.t. to exclude `tests*` and `docs*` from package distribution.