### PR TITLE
Support different compressors per level

### DIFF
--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -250,7 +250,7 @@ class ImageConverter:
             if isinstance(compressor, Mapping):
                 if len(compressor.items()) != reader.level_count:
                     raise ValueError(
-                        "Compressor filter mapping does not map every level to a Filter"
+                        f"Compressor filter mapping does not map every level to a Filter {len(compressor.items())} != {reader.level_count}"
                     )
 
             compressors = {}

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -5,7 +5,16 @@ import warnings
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from operator import itemgetter
-from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    Any,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 import numpy as np
 from tqdm import tqdm
@@ -25,6 +34,7 @@ from ..helpers import (
     get_pixel_depth,
     get_schema,
     iter_levels_meta,
+    iter_pixel_depths_meta,
     open_bioimg,
 )
 from ..openslide import TileDBOpenSlide
@@ -177,7 +187,7 @@ class ImageConverter:
         preserve_axes: bool = False,
         chunked: bool = False,
         max_workers: int = 0,
-        compressor: tiledb.Filter = tiledb.ZstdFilter(level=0),
+        compressor: Optional[Union[Mapping[int, Any], Any]] = None,
         reader_kwargs: Mapping[str, Any] = {},
         pyramid_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> None:
@@ -197,7 +207,7 @@ class ImageConverter:
             original ones.
         :param max_workers: Maximum number of threads that can be used for conversion.
             Applicable only if chunked=True.
-        :param compressor: TileDB compression filter
+        :param compressor: TileDB compression filter mapping for each level
         :param reader_kwargs: Keyword arguments passed to the _ImageReaderType constructor.
         :param pyramid_kwargs: Keyword arguments passed to the scaler constructor for
             generating downsampled versions of the base level. Valid keyword arguments are:
@@ -236,15 +246,32 @@ class ImageConverter:
                     f"current version is {PKG_VERSION}, stored version is {stored_pkg_version}"
                 )
 
-            if (
-                isinstance(compressor, tiledb.WebpFilter)
-                and compressor.input_format == WebpInputFormat.WEBP_NONE
-            ):
-                compressor = tiledb.WebpFilter(
-                    input_format=reader.webp_format,
-                    quality=compressor.quality,
-                    lossless=compressor.lossless,
-                )
+            # Check if compressor Mapping has 1-1 correspondance
+            if isinstance(compressor, Mapping):
+                if len(compressor.items()) != reader.level_count:
+                    raise ValueError(
+                        "Compressor filter mapping does not map every level to a Filter"
+                    )
+
+            compressors = {}
+            for level in range(level_min, reader.level_count):
+                if compressor is None:
+                    compressors[level] = tiledb.ZstdFilter(level=0)
+                elif isinstance(compressor, tiledb.Filter):
+                    if (
+                        isinstance(compressor, tiledb.WebpFilter)
+                        and compressor.input_format == WebpInputFormat.WEBP_NONE
+                    ):
+                        compressor = tiledb.WebpFilter(
+                            input_format=reader.webp_format,
+                            quality=compressor.quality,
+                            lossless=compressor.lossless,
+                        )
+                    # One filter is given apply to all levels
+                    compressors[level] = compressor
+                elif isinstance(compressor, Mapping):
+                    compressors = compressor  # type: ignore
+                    break
 
             convert_kwargs = dict(
                 reader=reader,
@@ -253,27 +280,31 @@ class ImageConverter:
                 preserve_axes=preserve_axes,
                 chunked=chunked,
                 max_workers=max_workers,
-                compressor=compressor,
+                compressor=compressors,
             )
+
+            scaled_compressors: Mapping[int, Any] = {}
             if pyramid_kwargs is not None:
                 if level_min < reader.level_count - 1:
                     warnings.warn(
                         f"The image contains multiple levels but only level {level_min} "
                         "will be considered for generating the image pyramid"
                     )
-                uri = _convert_level_to_tiledb(level_min, **convert_kwargs)
-                create_image_pyramid(
-                    rw_group, uri, level_min, max_tiles, compressor, pyramid_kwargs
+                uri = _convert_level_to_tiledb(level_min, **convert_kwargs)  # type: ignore
+                scaled_compressors = create_image_pyramid(
+                    rw_group, uri, level_min, max_tiles, compressors, pyramid_kwargs
                 )
             else:
                 for level in range(level_min, reader.level_count):
-                    _convert_level_to_tiledb(level, **convert_kwargs)
+                    _convert_level_to_tiledb(level, **convert_kwargs)  # type: ignore
 
         with rw_group:
             rw_group.w_group.meta.update(
                 reader.group_metadata,
                 axes=reader.axes.dims,
-                pixel_depth=get_pixel_depth(compressor),
+                pixel_depth=json.dumps(
+                    dict(iter_pixel_depths_meta({**compressors, **scaled_compressors}))
+                ),
                 pkg_version=PKG_VERSION,
                 fmt_version=FMT_VERSION,
                 dataset_type=DATASET_TYPE,
@@ -293,12 +324,12 @@ def _convert_level_to_tiledb(
     preserve_axes: bool,
     chunked: bool,
     max_workers: int,
-    compressor: tiledb.Filter,
+    compressor: Mapping[int, tiledb.Filter],
 ) -> str:
     # create mapper from source to target axes
     source_axes = reader.axes
     source_shape = reader.level_shape(level)
-    pixel_depth = get_pixel_depth(compressor)
+    pixel_depth = get_pixel_depth(compressor.get(level, tiledb.ZstdFilter(level=0)))
     if pixel_depth == 1:
         if preserve_axes:
             target_axes = source_axes
@@ -314,7 +345,13 @@ def _convert_level_to_tiledb(
     # create TileDB schema
     dim_shape = axes_mapper.map_shape(source_shape)
     attr_dtype = reader.level_dtype(level)
-    schema = get_schema(dim_names, dim_shape, max_tiles, attr_dtype, compressor)
+    schema = get_schema(
+        dim_names,
+        dim_shape,
+        max_tiles,
+        attr_dtype,
+        compressor.get(level, tiledb.ZstdFilter(level=0)),
+    )
 
     # get or create TileDB array uri
     uri, created = rw_group.get_or_create(f"l_{level}.tdb", schema)

--- a/tiledb/bioimg/converters/scale.py
+++ b/tiledb/bioimg/converters/scale.py
@@ -1,5 +1,5 @@
 from concurrent import futures
-from typing import Any, Optional, Sequence, Tuple
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
 import skimage as sk
 
@@ -28,7 +28,7 @@ class Scaler(object):
         )
         self._level_shapes = []
         self._scale_factors = []
-
+        self._scale_compressors: Dict[int, tiledb.Filter] = {}
         previous_scale_factor = 1.0
         for scale_factor in scale_factors:
             dim_factors = [
@@ -62,6 +62,13 @@ class Scaler(object):
     @property
     def progressive(self) -> bool:
         return self._progressive
+
+    @property
+    def compressors(self) -> Mapping[int, tiledb.Filter]:
+        return self._scale_compressors
+
+    def update_compressors(self, level: int, lvl_filter: tiledb.Filter) -> None:
+        self._scale_compressors[level] = lvl_filter
 
     def apply(
         self, in_array: tiledb.Array, out_array: tiledb.Array, level: int

--- a/tiledb/bioimg/openslide.py
+++ b/tiledb/bioimg/openslide.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     pass
 
+import json
+
 import tiledb
 
 from . import ATTR_NAME
@@ -34,7 +36,8 @@ class TileDBOpenSlide:
         :param uri: uri of a tiledb.Group containing the image
         """
         self._group = tiledb.Group(uri)
-        pixel_depth = self._group.meta.get("pixel_depth", 1)
+        pixel_depth = self._group.meta.get("pixel_depth", "")
+        pixel_depth = dict(json.loads(pixel_depth)) if pixel_depth else {}
         self._levels = sorted(
             (TileDBOpenSlideLevel(o.uri, pixel_depth, attr=attr) for o in self._group),
             key=attrgetter("level"),
@@ -155,9 +158,9 @@ class TileDBOpenSlide:
 
 
 class TileDBOpenSlideLevel:
-    def __init__(self, uri: str, pixel_depth: int, *, attr: str):
+    def __init__(self, uri: str, pixel_depth: Mapping[str, int], *, attr: str):
         self._tdb = open_bioimg(uri, attr=attr)
-        self._pixel_depth = pixel_depth
+        self._pixel_depth = pixel_depth.get(str(self.level), 1)
 
     @property
     def level(self) -> int:


### PR DESCRIPTION
This PR:

- Enables the user to ingest a multi-layer image by compressing each level with a separate filter.
- The default compression filter remains to be `Zstd` as it used to be.
- The user can either select a filter to be applied to all levels of the image `or` provide a mapping of levels -> filter for each image
- In the case of scaling an image with our `Scaler`, the newly constructed scaled levels are being compressed/filtered with the filter of the `base_layer`
-  In the metadata section due to this feature we have a change as now the `pixel_depth` value can differ among the different levels as it is a function of the filter that is used. We store this information in the group metadata as a Mapping as well.
- The changes were done in a way that the API of the `to_tiledb` does not change.
- Possibly alongside with some other changes that are happening in other PRs like `channel metadata` we will have to update the `FMT_VERSION` when released.