### PR TITLE
Investigating exporting issue with VFS FileHandle

### DIFF
--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -136,7 +136,7 @@ def test_ome_tiff_converter_roundtrip(
         ),
     )
     # Store it back to NGFF Zarr
-    OMETiffConverter.from_tiledb(str(tiledb_path), output_path)
+    OMETiffConverter.from_tiledb(str(tiledb_path), str(output_path))
 
     with tifffile.TiffFile(input_path) as t1, tifffile.TiffFile(output_path) as t2:
         compare_tifffiles(t1, t2)
@@ -184,7 +184,7 @@ def test_ome_tiff_converter_artificial_rountrip(tmp_path, filename, dims, tiles)
         if A.domain.has_dim("T"):
             assert A.dim("T").tile == tiles.get("T", 1)
 
-    OMETiffConverter.from_tiledb(str(tiledb_path), output_path)
+    OMETiffConverter.from_tiledb(str(tiledb_path), str(output_path))
     with tifffile.TiffFile(input_path) as t1, tifffile.TiffFile(output_path) as t2:
         compare_tifffiles(t1, t2)
         compare_tiff_page_series(t1.series[0], t2.series[0])

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -119,7 +119,7 @@ def test_ome_zarr_converter_rountrip(
         compressor=compressor,
     )
     # Store it back to NGFF Zarr
-    OMEZarrConverter.from_tiledb(str(tiledb_path), output_path)
+    OMEZarrConverter.from_tiledb(str(tiledb_path), str(output_path))
 
     # Same number of levels
     input_group = zarr.open_group(input_path, mode="r")

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -167,7 +167,7 @@ class ImageConverter:
         *,
         level_min: int = 0,
         attr: str = ATTR_NAME,
-        config: Union[tiledb.Config, Mapping[str, Any]] = None
+        config: Union[tiledb.Config, Mapping[str, Any]] = None,
     ) -> None:
         """
         Convert a TileDB Group of Arrays back to other format images, one per level
@@ -181,11 +181,14 @@ class ImageConverter:
         if cls._ImageWriterType is None:
             raise NotImplementedError(f"{cls} does not support exporting")
 
-        destination_uri = output_path
         if config is not None:
-            cfg = tiledb.Config(params = config) if isinstance(config, Mapping) else config
+            cfg = (
+                tiledb.Config(params=config) if isinstance(config, Mapping) else config
+            )
             vfs = tiledb.VFS(config=cfg)
-            destination_uri = vfs.open(output_path, 'wb')
+            destination_uri = vfs.open(output_path, "wb")
+        else:
+            destination_uri = output_path
 
         slide = TileDBOpenSlide(input_path, attr=attr)
         writer = cls._ImageWriterType(destination_uri)

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -181,9 +181,12 @@ class ImageConverter:
         if cls._ImageWriterType is None:
             raise NotImplementedError(f"{cls} does not support exporting")
 
-        if config is not None:
+        vfs_use = output_path.startswith("s3://")
+        if vfs_use:
             cfg = (
-                tiledb.Config(params=config) if isinstance(config, Mapping) else config
+                tiledb.Config(params=dict(config))
+                if isinstance(config, Mapping)
+                else config
             )
             vfs = tiledb.VFS(config=cfg)
             destination_uri = vfs.open(output_path, "wb")
@@ -202,7 +205,7 @@ class ImageConverter:
                 level_metadata = slide.level_properties(level)
                 writer.write_level_image(level, level_image, level_metadata)
 
-        if config:
+        if vfs_use:
             destination_uri.close()
 
     @classmethod

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -167,21 +167,29 @@ class ImageConverter:
         *,
         level_min: int = 0,
         attr: str = ATTR_NAME,
+        config: Union[tiledb.Config, Mapping[str, Any]] = None
     ) -> None:
         """
-        Convert a TileDB Group of Arrays back to other format images, one per level.
-
+        Convert a TileDB Group of Arrays back to other format images, one per level
         :param input_path: path to the TileDB group of arrays
         :param output_path: path to the image
         :param level_min: minimum level of the image to be converted. By default set to 0
-            to convert all levels.
+            to convert all levels
         :param attr: attribute name for backwards compatiblity support
+        :param config: tiledb configuration either a dict or a tiledb.Config
         """
         if cls._ImageWriterType is None:
             raise NotImplementedError(f"{cls} does not support exporting")
 
+        destination_uri = output_path
+        if config is not None:
+            cfg = tiledb.Config(params = config) if isinstance(config, Mapping) else config
+            vfs = tiledb.VFS(config=cfg)
+            destination_uri = vfs.open(output_path, 'wb')
+
         slide = TileDBOpenSlide(input_path, attr=attr)
-        writer = cls._ImageWriterType(output_path)
+        writer = cls._ImageWriterType(destination_uri)
+
         with slide, writer:
             writer.write_group_metadata(slide.properties)
             for level in slide.levels:
@@ -190,6 +198,9 @@ class ImageConverter:
                 level_image = slide.read_level(level, to_original_axes=True)
                 level_metadata = slide.level_properties(level)
                 writer.write_level_image(level, level_image, level_metadata)
+
+        if config:
+            destination_uri.close()
 
     @classmethod
     def to_tiledb(

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -271,8 +271,9 @@ class OMETiffWriter(ImageWriter):
 
     def write_group_metadata(self, metadata: Mapping[str, Any]) -> None:
         tiffwriter_kwargs = json.loads(metadata["json_tiffwriter_kwargs"])
+        tiffwriter_kwargs.pop('append')
         self._writer = tifffile.TiffWriter(
-            self._output_path, shaped=False, **tiffwriter_kwargs
+            self._output_path, shaped=False, append=False, **tiffwriter_kwargs
         )
 
     def write_level_image(

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -271,7 +271,7 @@ class OMETiffWriter(ImageWriter):
 
     def write_group_metadata(self, metadata: Mapping[str, Any]) -> None:
         tiffwriter_kwargs = json.loads(metadata["json_tiffwriter_kwargs"])
-        tiffwriter_kwargs.pop('append')
+        tiffwriter_kwargs.pop("append")
         self._writer = tifffile.TiffWriter(
             self._output_path, shaped=False, append=False, **tiffwriter_kwargs
         )


### PR DESCRIPTION
This PR:

- Fixes the behaviour of the `from_tiledb` API complementing https://app.shortcut.com/tiledb-inc/story/30787/vfs-write-to-s3-uri-fails-to-write. The VFS handle opens and close inside the function