### PR TITLE
Exporter Wrapper to_bioimg

### DIFF
--- a/tests/integration/test_wrappers.py
+++ b/tests/integration/test_wrappers.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tests import get_path
-from tiledb.bioimg import Converters, from_bioimg
+from tiledb.bioimg import Converters, from_bioimg, to_bioimg
 from tiledb.bioimg.converters.ome_tiff import OMETiffConverter
 from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter
 from tiledb.bioimg.converters.openslide import OpenSlideConverter
@@ -21,13 +21,16 @@ from tiledb.bioimg.converters.openslide import OpenSlideConverter
 def test_from_bioimg_wrapper(tmp_path, converter, file_path):
     input_path = get_path(file_path)
     output_path = str(tmp_path)
+    output_path_round = str(tmp_path) + "/roundtrip"
     if converter == Converters.OMETIFF:
-        rtype = from_bioimg(input_path, output_path, converter=converter)
-        assert rtype == OMETiffConverter
+        rfromtype = from_bioimg(input_path, output_path, converter=converter)
+        rtotype = to_bioimg(output_path, output_path_round, converter=converter)
+        assert rfromtype == rtotype == OMETiffConverter
     elif converter == Converters.OSD:
         rtype = from_bioimg(input_path, output_path, converter=converter)
         assert rtype == OpenSlideConverter
     else:
         input_path = input_path / str(0)
-        rtype = from_bioimg(input_path, output_path, converter=converter)
-        assert rtype == OMEZarrConverter
+        rfromtype = from_bioimg(input_path, output_path, converter=converter)
+        rtotype = to_bioimg(output_path, output_path_round, converter=converter)
+        assert rfromtype == rtotype == OMEZarrConverter

--- a/tests/integration/test_wrappers.py
+++ b/tests/integration/test_wrappers.py
@@ -29,6 +29,8 @@ def test_from_bioimg_wrapper(tmp_path, converter, file_path):
     elif converter == Converters.OSD:
         rtype = from_bioimg(input_path, output_path, converter=converter)
         assert rtype == OpenSlideConverter
+        with pytest.raises(NotImplementedError):
+            to_bioimg(output_path, output_path_round, converter=converter)
     else:
         input_path = input_path / str(0)
         rfromtype = from_bioimg(input_path, output_path, converter=converter)

--- a/tiledb/bioimg/__init__.py
+++ b/tiledb/bioimg/__init__.py
@@ -3,4 +3,4 @@ WHITE_RGB = 16777215  # FFFFFF in hex
 WHITE_RGBA = 4294967295  # FFFFFFFF in hex
 
 from .types import Converters
-from .wrappers import from_bioimg
+from .wrappers import from_bioimg, to_bioimg

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -168,7 +168,7 @@ class ImageConverter:
         level_min: int = 0,
         attr: str = ATTR_NAME,
         config: Union[tiledb.Config, Mapping[str, Any]] = None,
-    ) -> None:
+    ) -> Type[ImageConverter]:
         """
         Convert a TileDB Group of Arrays back to other format images, one per level
         :param input_path: path to the TileDB group of arrays
@@ -203,6 +203,8 @@ class ImageConverter:
 
             if vfs_use:
                 destination_uri.close()
+
+        return cls
 
     @classmethod
     def to_tiledb(
@@ -262,9 +264,8 @@ class ImageConverter:
         else:
             raise NotImplementedError(f"{cls} does not support importing")
 
-        max_tiles = cls._DEFAULT_TILES
-        if tiles:
-            max_tiles.update(tiles)
+        max_tiles = cls._DEFAULT_TILES.copy()
+        max_tiles.update(tiles)
 
         rw_group = ReadWriteGroup(output_path)
 

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -262,8 +262,9 @@ class ImageConverter:
         else:
             raise NotImplementedError(f"{cls} does not support importing")
 
-        max_tiles = cls._DEFAULT_TILES.copy()
-        max_tiles.update(tiles)
+        max_tiles = cls._DEFAULT_TILES
+        if tiles:
+            max_tiles.update(tiles)
 
         rw_group = ReadWriteGroup(output_path)
 

--- a/tiledb/bioimg/wrappers.py
+++ b/tiledb/bioimg/wrappers.py
@@ -31,7 +31,7 @@ def from_bioimg(
 
 def to_bioimg(
     src: str, dest: str, converter: Converters = Converters.OMETIFF, **kwargs: Any
-) -> None:
+) -> Type[ImageConverter]:
     """
     This function is a wrapper and serves as an all-inclusive API for encapsulating the
     exportation of TileDB ingested bio-images back into different file formats

--- a/tiledb/bioimg/wrappers.py
+++ b/tiledb/bioimg/wrappers.py
@@ -12,9 +12,41 @@ from .types import Converters
 def from_bioimg(
     src: str, dest: str, converter: Converters = Converters.OMETIFF, **kwargs: Any
 ) -> Type[ImageConverter]:
+    """
+    This function is a wrapper and serves as an all-inclusive API for encapsulating the
+    ingestion of different file formats
+    :param src: The source path for the file to be ingested *.tiff, *.zarr, *.svs etc..
+    :param dest: The destination path where the TileDB image will be stored
+    :param converter: The converter type to be used (tentative) soon automatically detected
+    :param kwargs: keyword arguments for custom ingestion behaviour
+    :return: The converter class that was used for the ingestion
+    """
     if converter is Converters.OMETIFF:
         return OMETiffConverter.to_tiledb(source=src, output_path=dest, **kwargs)
     elif converter is Converters.OMEZARR:
         return OMEZarrConverter.to_tiledb(source=src, output_path=dest, **kwargs)
     else:
         return OpenSlideConverter.to_tiledb(source=src, output_path=dest, **kwargs)
+
+
+def to_bioimg(
+    src: str, dest: str, converter: Converters = Converters.OMETIFF, **kwargs: Any
+) -> None:
+    """
+    This function is a wrapper and serves as an all-inclusive API for encapsulating the
+    exportation of TileDB ingested bio-images back into different file formats
+    :param src: The source path where the TileDB image is stored
+    :param dest: The destination path for the image file to be exported *.tiff, *.zarr, *.svs etc..
+    :param converter: The converter type to be used
+    :param kwargs: keyword arguments for custom exportation behaviour
+    :return: None
+    """
+
+    if converter is Converters.OMETIFF:
+        return OMETiffConverter.from_tiledb(input_path=src, output_path=dest, **kwargs)
+    elif converter is Converters.OMEZARR:
+        return OMEZarrConverter.from_tiledb(input_path=src, output_path=dest, **kwargs)
+    else:
+        raise NotImplementedError(
+            "Openslide Converter does not support exportation back to bio-imaging formats"
+        )


### PR DESCRIPTION
This PR:

- Creates a wrapper similar to `from_bioimg` #89 wrapper but this time for the export functionality. Utilizes the `to_tiledb` API