### PR TITLE
TIFF Random Access Fix

### DIFF
--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-import os.path
+import os
 import warnings
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
@@ -39,15 +39,19 @@ from ..helpers import (
     get_axes_mapper,
     get_axes_translation,
     get_schema,
+    is_local_path,
     iter_levels_meta,
     iter_pixel_depths_meta,
     open_bioimg,
+    resolve_path,
 )
 from ..openslide import TileDBOpenSlide
 from ..version import version as PKG_VERSION
 from . import DATASET_TYPE, FMT_VERSION
 from .axes import Axes
 from .tiles import iter_tiles, num_tiles
+
+DEFAULT_SCRATCH_SPACE = "/dev/shm"
 
 
 class ImageReader(ABC):
@@ -169,6 +173,7 @@ class ImageConverter:
         level_min: int = 0,
         attr: str = ATTR_NAME,
         config: Union[tiledb.Config, Mapping[str, Any]] = None,
+        scratch_space: str = DEFAULT_SCRATCH_SPACE,
     ) -> Type[ImageConverter]:
         """
         Convert a TileDB Group of Arrays back to other format images, one per level
@@ -178,14 +183,20 @@ class ImageConverter:
             to convert all levels
         :param attr: attribute name for backwards compatiblity support
         :param config: tiledb configuration either a dict or a tiledb.Config
+        :param scratch_space: shared memory or cache space for cloud random access export support
         """
         if cls._ImageWriterType is None:
             raise NotImplementedError(f"{cls} does not support exporting")
 
         with tiledb.scope_ctx(config):
-            vfs_use = output_path.startswith("s3://")
+            out_uri_res, scheme = resolve_path(output_path)
+            vfs_use = False if is_local_path(scheme) else True
+
+            # OS specific
             destination_uri = (
-                f"/dev/shm/{os.path.basename(output_path)}" if vfs_use else output_path
+                os.path.join(scratch_space, os.path.basename(out_uri_res))
+                if vfs_use
+                else out_uri_res
             )
             slide = TileDBOpenSlide(input_path, attr=attr)
             writer = cls._ImageWriterType(destination_uri)
@@ -200,6 +211,7 @@ class ImageConverter:
                     writer.write_level_image(level, level_image, level_metadata)
 
             if vfs_use:
+                # Flush to remote
                 with open(destination_uri, "rb") as data:
                     vfs = tiledb.VFS()
                     with vfs.open(output_path, "wb") as dest:

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -182,27 +182,19 @@ class ImageConverter:
             raise NotImplementedError(f"{cls} does not support exporting")
 
         with tiledb.scope_ctx(config):
-            vfs_use = output_path.startswith("s3://")
-            if vfs_use:
-                vfs = tiledb.VFS()
-                destination_uri = vfs.open(output_path, "wb")
-            else:
-                destination_uri = output_path
+            vfs = tiledb.VFS()
+            with vfs.open(output_path, "wb") as destination:
+                slide = TileDBOpenSlide(input_path, attr=attr)
+                writer = cls._ImageWriterType(destination)
 
-            slide = TileDBOpenSlide(input_path, attr=attr)
-            writer = cls._ImageWriterType(destination_uri)
-
-            with slide, writer:
-                writer.write_group_metadata(slide.properties)
-                for level in slide.levels:
-                    if level < level_min:
-                        continue
-                    level_image = slide.read_level(level, to_original_axes=True)
-                    level_metadata = slide.level_properties(level)
-                    writer.write_level_image(level, level_image, level_metadata)
-
-            if vfs_use:
-                destination_uri.close()
+                with slide, writer:
+                    writer.write_group_metadata(slide.properties)
+                    for level in slide.levels:
+                        if level < level_min:
+                            continue
+                        level_image = slide.read_level(level, to_original_axes=True)
+                        level_metadata = slide.level_properties(level)
+                        writer.write_level_image(level, level_image, level_metadata)
 
         return cls
 

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -196,3 +196,23 @@ def compute_channel_minmax(
 ) -> None:
     min_max[:, 0] = np.minimum(min_max[:, 0], tile_min)
     min_max[:, 1] = np.maximum(min_max[:, 1], tile_max)
+
+
+def resolve_path(uri: str) -> Tuple[str, str]:
+    parsed_uri = urlparse(uri)
+    # normalize uri if it's a local path (e.g. ../..foo/bar)
+
+    # Windows paths produce single letter scheme matching the drive letter
+    # Unix absolute path produce an empty scheme
+    resolved_uri = parsed_uri.path
+    if is_win_path(parsed_uri.scheme):
+        resolved_uri = str(Path(parsed_uri.path).resolve()).replace("\\", "/")
+    return resolved_uri, parsed_uri.scheme
+
+
+def is_win_path(scheme: str) -> bool:
+    return len(scheme) < 2 or scheme == "file"
+
+
+def is_local_path(scheme: str) -> bool:
+    return True if is_win_path(scheme) or scheme == "" else False


### PR DESCRIPTION
This PR:

- Complements the investigation of [sc-30748] and it is a workaround for random access writes of `tifffile` dependency. This fix is OS specific.

