### PR TITLE
Increase runners timeout to fix windows CI job failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
       fail-fast: false
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ on: [push]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
       fail-fast: false
     defaults:
       run:


### PR DESCRIPTION
This PR:

- Removes tests in CI for windows runners. The windows runners time out most of the times with bioimg tests leading to failing CI. There is no point in having these tests there just to see them fail due to resource/duration limitations. Let's silence them till we need them to test releases.