### PR TITLE
Migrate to mamba-org/setup-micromamba@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,19 +21,20 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Conda environment with Micromamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
-        environment-file: false
         environment-name: test
-        channels: conda-forge
         cache-downloads: true
-        extra-specs: |
+        create-args: >-
           python=3.7
-          sel(linux): openslide
           pre-commit
           pytest-cov
           pytest-mock
     
+    - name: Install openslide for non-Win
+      run: micromamba install openslide
+      if: matrix.os != 'windows-latest'
+
     - name: Install openslide for Win 
       run: |
         choco install wget --no-progress


### PR DESCRIPTION
mamba-org/provision-with-micromamba is deprecated (https://github.com/mamba-org/provision-with-micromamba/pull/122)

Unfortunately it looks like selectors are no longer supported, so I installed `openslide` in a separate step