### PR TITLE
Update tifffile version and unpin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "pyeditdistance",
         "tiledb>=0.19",
         "tqdm",
-        "tifffile==2022.10.10",
+        "tifffile",
         "scikit-image",
     ],
     extras_require={


### PR DESCRIPTION
After the discussion https://tiledb.slack.com/archives/G01CJSR8G9H/p1695218069855349
I investigated the issue with 0-value arrays during chunk ingestion and it seems that the issue is known https://github.com/zarr-developers/zarr-python/issues/1497. This issue was fixed and released in version `2.16`. 
However for this upgrade to be applied I had to update our tifffile dependency from the pinned version `10.10.2022` to a later one.

The reason for pinning this `tifffile` version in the first place was that during the chunk ingestion of proprietary data, we were failing specifically on only these with a weird runtime `IndexError` reported here https://app.shortcut.com/tiledb-inc/story/30274/investigate-indexerror-from-zarrstore-when-chunked-true. 

Following up a discussion with the author of `tifffile` https://github.com/cgohlke/tifffile/issues/227  we were able to "roll back" the functionality of the corresponding code to a similar behaviour with the 10.10.2022 version in the latest release `2023.9.26`

The real reason behind this failure might be corrupted files although when I validated with [jhove](https://jhove.openpreservation.org/getting-started/) I was getting valid status. 

In any case IMO it is important to unpin the specific version, the current tests run successfully and the same applies for the proprietary data as well.
