### PR TITLE
Logger for tiledb-bioimg

### DIFF
--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -126,6 +126,7 @@ def test_ome_tiff_converter_roundtrip(
         chunked=chunked,
         max_workers=max_workers,
         compressor=compressor,
+        log=False,
         reader_kwargs=dict(
             extra_tags=(
                 "ModelPixelScaleTag",

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -8,7 +8,7 @@ import zarr
 import tiledb
 from tests import assert_image_similarity, get_path, get_schema
 from tiledb.bioimg.converters import DATASET_TYPE, FMT_VERSION
-from tiledb.bioimg.converters.ome_tiff import OMETiffConverter, OMETiffReader
+from tiledb.bioimg.converters.ome_tiff import OMETiffReader
 from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter, OMEZarrReader
 from tiledb.bioimg.helpers import iter_color, open_bioimg
 from tiledb.bioimg.openslide import TileDBOpenSlide
@@ -25,11 +25,11 @@ def test_ome_zarr_converter_source_reader_exception(
     tiff_path = get_path("CMU-1-Small-Region.ome.tiff")
     output_reader = tmp_path / "to_tiledb_reader"
 
-    # with pytest.raises(ValueError) as excinfo:
-    OMETiffConverter.to_tiledb(
-        OMETiffReader(tiff_path), str(output_reader), preserve_axes=preserve_axes
-    )
-    # assert "reader should match converter" in str(excinfo)
+    with pytest.raises(ValueError) as excinfo:
+        OMEZarrConverter.to_tiledb(
+            OMETiffReader(tiff_path), str(output_reader), preserve_axes=preserve_axes
+        )
+    assert "reader should match converter" in str(excinfo)
 
 
 @pytest.mark.parametrize("series_idx", [0, 1, 2])

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -8,7 +8,7 @@ import zarr
 import tiledb
 from tests import assert_image_similarity, get_path, get_schema
 from tiledb.bioimg.converters import DATASET_TYPE, FMT_VERSION
-from tiledb.bioimg.converters.ome_tiff import OMETiffReader
+from tiledb.bioimg.converters.ome_tiff import OMETiffConverter, OMETiffReader
 from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter, OMEZarrReader
 from tiledb.bioimg.helpers import iter_color, open_bioimg
 from tiledb.bioimg.openslide import TileDBOpenSlide
@@ -25,11 +25,11 @@ def test_ome_zarr_converter_source_reader_exception(
     tiff_path = get_path("CMU-1-Small-Region.ome.tiff")
     output_reader = tmp_path / "to_tiledb_reader"
 
-    with pytest.raises(ValueError) as excinfo:
-        OMEZarrConverter.to_tiledb(
-            OMETiffReader(tiff_path), str(output_reader), preserve_axes=preserve_axes
-        )
-    assert "reader should match converter" in str(excinfo)
+    # with pytest.raises(ValueError) as excinfo:
+    OMETiffConverter.to_tiledb(
+        OMETiffReader(tiff_path), str(output_reader), preserve_axes=preserve_axes
+    )
+    # assert "reader should match converter" in str(excinfo)
 
 
 @pytest.mark.parametrize("series_idx", [0, 1, 2])

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -35,7 +35,9 @@ class OpenSlideReader(ImageReader):
 
     @property
     def axes(self) -> Axes:
-        return Axes("YXC")
+        axes = Axes("YXC")
+        self._logger.debug(f"Reader axes: {axes}")
+        return axes
 
     @property
     def channels(self) -> Sequence[str]:
@@ -43,20 +45,26 @@ class OpenSlideReader(ImageReader):
 
     @property
     def webp_format(self) -> WebpInputFormat:
+        self._logger.debug(f"Webp Input Format: {WebpInputFormat.WEBP_RGBA}")
         return WebpInputFormat.WEBP_RGBA
 
     @property
     def level_count(self) -> int:
-        return cast(int, self._osd.level_count)
+        level_count = cast(int, self._osd.level_count)
+        self._logger.debug(f"Level count: {level_count}")
+        return level_count
 
     def level_dtype(self, level: int) -> np.dtype:
-        return np.dtype(np.uint8)
+        dtype = np.dtype(np.uint8)
+        self._logger.debug(f"Level {level} dtype: {dtype}")
+        return dtype
 
     def level_shape(self, level: int) -> Tuple[int, ...]:
         width, height = self._osd.level_dimensions[level]
         # OpenSlide.read_region() returns a PIL image in RGBA mode
         # passing it to np.asarray() returns a (height, width, 4) array
         # https://stackoverflow.com/questions/49084846/why-different-size-when-converting-pil-image-to-numpy-array
+        self._logger.debug(f"Level {level} shape: ({width}, {height}, 4)")
         return height, width, 4
 
     def level_image(
@@ -80,10 +88,12 @@ class OpenSlideReader(ImageReader):
         return np.asarray(self._osd.read_region(location, level, size))
 
     def level_metadata(self, level: int) -> Dict[str, Any]:
+        self._logger.debug(f"Level {level} - Metadata: None")
         return {}
 
     @property
     def group_metadata(self) -> Dict[str, Any]:
+        self._logger.debug("Group metadata: None")
         return {}
 
     @property
@@ -104,6 +114,7 @@ class OpenSlideReader(ImageReader):
             )
             metadata["physicalSizeYUnit"] = metadata["physicalSizeYUnit"] = "µm"
 
+        self._logger.debug(f"Image metadata: {metadata}")
         return metadata
 
     @property

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Dict, Optional, Sequence, Tuple, cast
 
 import numpy as np
@@ -5,23 +6,32 @@ import openslide as osd
 
 from tiledb.cc import WebpInputFormat
 
-from ..helpers import iter_color
+from ..helpers import get_logger_wrapper, iter_color
 from .axes import Axes
 from .base import ImageConverter, ImageReader
 
 
 class OpenSlideReader(ImageReader):
-    def __init__(self, input_path: str):
+    def __init__(self, input_path: str, logger: Optional[logging.Logger] = None):
         """
         OpenSlide image reader
 
         :param input_path: The path to the OpenSlide image
 
         """
+        self._logger = get_logger_wrapper(False) if not logger else logger
         self._osd = osd.OpenSlide(input_path)
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self._osd.close()
+
+    @property
+    def logger(self) -> Optional[logging.Logger]:
+        return self._logger
+
+    @logger.setter
+    def logger(self, default_logger: logging.Logger) -> None:
+        self._logger = default_logger
 
     @property
     def axes(self) -> Axes:

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -298,7 +298,7 @@ def get_logger_wrapper(
     :return: logger instance
     """
 
-    level = logging.DEBUG if verbose else logging.INFO
+    level = logging.DEBUG if verbose else logging.WARNING
     logger = get_logger(level)
 
     logger.debug(

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from pathlib import Path
@@ -14,6 +15,7 @@ from tiledb.cc import WebpInputFormat
 
 from . import ATTR_NAME
 from .converters.axes import Axes, AxesMapper
+from .version import version_tuple
 
 
 class ReadWriteGroup:
@@ -260,3 +262,50 @@ def is_win_path(scheme: str) -> bool:
 
 def is_local_path(scheme: str) -> bool:
     return True if is_win_path(scheme) or scheme == "" else False
+
+
+def get_logger(level: int = logging.INFO, name: str = __name__) -> logging.Logger:
+    """
+    Get a logger with a custom formatter and set the logging level.
+
+    :param level: logging level, defaults to logging.INFO
+    :param name: logger name, defaults to __name__
+    :return: Logger object
+    """
+
+    sh = logging.StreamHandler(stream=sys.stdout)
+    formatter = logging.Formatter(
+        "[%(asctime)s] [%(module)s] [%(funcName)s] [%(levelname)s] %(message)s"
+    )
+    sh.setFormatter(formatter)
+
+    logger = logging.getLogger(name)
+    # Only add one handler, in case get_logger is called multiple times
+    if not logger.handlers:
+        logger.addHandler(sh)
+        logger.setLevel(level)
+
+    return logger
+
+
+def get_logger_wrapper(
+    verbose: bool = False,
+) -> logging.Logger:
+    """
+    Get a logger instance and log version information.
+
+    :param verbose: verbose logging, defaults to False
+    :return: logger instance
+    """
+
+    level = logging.DEBUG if verbose else logging.INFO
+    logger = get_logger(level)
+
+    logger.debug(
+        "tiledb=%s, libtiledb=%s, tiledb-bioimg=%s",
+        tiledb.version(),
+        tiledb.libtiledb.version(),
+        version_tuple,
+    )
+
+    return logger

--- a/tiledb/bioimg/wrappers.py
+++ b/tiledb/bioimg/wrappers.py
@@ -6,11 +6,17 @@ from .converters.base import ImageConverter
 from .converters.ome_tiff import OMETiffConverter
 from .converters.ome_zarr import OMEZarrConverter
 from .converters.openslide import OpenSlideConverter
+from .helpers import get_logger_wrapper
 from .types import Converters
 
 
 def from_bioimg(
-    src: str, dest: str, converter: Converters = Converters.OMETIFF, **kwargs: Any
+    src: str,
+    dest: str,
+    converter: Converters = Converters.OMETIFF,
+    *,
+    verbose: bool = False,
+    **kwargs: Any,
 ) -> Type[ImageConverter]:
     """
     This function is a wrapper and serves as an all-inclusive API for encapsulating the
@@ -18,19 +24,35 @@ def from_bioimg(
     :param src: The source path for the file to be ingested *.tiff, *.zarr, *.svs etc..
     :param dest: The destination path where the TileDB image will be stored
     :param converter: The converter type to be used (tentative) soon automatically detected
+    :param verbose: verbose logging, defaults to False
     :param kwargs: keyword arguments for custom ingestion behaviour
     :return: The converter class that was used for the ingestion
     """
+    logger = get_logger_wrapper(verbose)
     if converter is Converters.OMETIFF:
-        return OMETiffConverter.to_tiledb(source=src, output_path=dest, **kwargs)
+        logger.info("Converting OME-TIFF file")
+        return OMETiffConverter.to_tiledb(
+            source=src, output_path=dest, log=logger, **kwargs
+        )
     elif converter is Converters.OMEZARR:
-        return OMEZarrConverter.to_tiledb(source=src, output_path=dest, **kwargs)
+        logger.info("Converting OME-Zarr file")
+        return OMEZarrConverter.to_tiledb(
+            source=src, output_path=dest, log=logger, **kwargs
+        )
     else:
-        return OpenSlideConverter.to_tiledb(source=src, output_path=dest, **kwargs)
+        logger.info("Converting Openslide")
+        return OpenSlideConverter.to_tiledb(
+            source=src, output_path=dest, log=logger, **kwargs
+        )
 
 
 def to_bioimg(
-    src: str, dest: str, converter: Converters = Converters.OMETIFF, **kwargs: Any
+    src: str,
+    dest: str,
+    converter: Converters = Converters.OMETIFF,
+    *,
+    verbose: bool = False,
+    **kwargs: Any,
 ) -> Type[ImageConverter]:
     """
     This function is a wrapper and serves as an all-inclusive API for encapsulating the
@@ -38,14 +60,21 @@ def to_bioimg(
     :param src: The source path where the TileDB image is stored
     :param dest: The destination path for the image file to be exported *.tiff, *.zarr, *.svs etc..
     :param converter: The converter type to be used
+    :param verbose: verbose logging, defaults to False
     :param kwargs: keyword arguments for custom exportation behaviour
     :return: None
     """
-
+    logger = get_logger_wrapper(verbose)
     if converter is Converters.OMETIFF:
-        return OMETiffConverter.from_tiledb(input_path=src, output_path=dest, **kwargs)
+        logger.info("Converting to OME-TIFF file")
+        return OMETiffConverter.from_tiledb(
+            input_path=src, output_path=dest, log=logger, **kwargs
+        )
     elif converter is Converters.OMEZARR:
-        return OMEZarrConverter.from_tiledb(input_path=src, output_path=dest, **kwargs)
+        logger.info("Converting to OME-Zarr file")
+        return OMEZarrConverter.from_tiledb(
+            input_path=src, output_path=dest, log=logger, **kwargs
+        )
     else:
         raise NotImplementedError(
             "Openslide Converter does not support exportation back to bio-imaging formats"


### PR DESCRIPTION
In this PR:

- We introduce a logger in `tiledb-bioimg` package for easier debugging. The logging in the current commit is mostly focused on OMETiffConverter, Reader, Writer and the corresponding APIs. This initial implementation bootstraps the logging of other Converters as well. The logging messages for the rest converters will be added in following commits.
- Due to the dual nature of our API (Wrappers and Converter functions) we introduce for the wrappers an extra argument called `verbose`. This boolean when set to `True`, will enable DEBUG mode across the function calls and when `False` it will just behave in WARNING level debugging. 
- For the Converters API (consisting of `to_tiledb` and `from_tiledb`) we introduce an extra arg called `log` as a `Union[bool, logging.Logger]`. The reasoning behind this is dual. First with a boolean arg we can use the calls standalone enabling their own logger . For the `logging.Logger` case we allow this way the integration with the wrapper API calls `from_bioimg` and `to_bioimg` as well as we enable the user to pass his/her own logger and integrate it with the rest of the package. 
- This PR will be connected to a PR in TileDB-Cloud-Py client so the logging could be enabled from the ingestion Graph as well.

A sample of the usage is below:
```
[2023-10-10 16:05:46,773] [helpers] [get_logger_wrapper] [DEBUG] tiledb=(0, 23, 0), libtiledb=(2, 17, 0), tiledb-bioimg=(0, 2, 4, 'dev12', 'dirty')
[2023-10-10 16:05:46,773] [base] [to_tiledb] [DEBUG] Max tiles:{'T': 1, 'C': inf, 'Z': 1, 'Y': 1024, 'X': 1024}
[2023-10-10 16:05:46,773] [base] [to_tiledb] [DEBUG] Updated max tiles:{'T': 1, 'C': inf, 'Z': 1, 'Y': 1024, 'X': 1024}
[2023-10-10 16:05:46,775] [base] [to_tiledb] [DEBUG] Format version: None
[2023-10-10 16:05:46,775] [ome_tiff] [level_count] [DEBUG] Level count: 2
[2023-10-10 16:05:46,775] [base] [to_tiledb] [DEBUG] Compressors : {0: ZstdFilter(level=0), 1: ZstdFilter(level=0)}
[2023-10-10 16:05:46,775] [base] [to_tiledb] [DEBUG] Convert arguments : {'reader': <tiledb.bioimg.converters.ome_tiff.OMETiffReader object at 0x1385b3430>, 'rw_group': <tiledb.bioimg.helpers.ReadWriteGroup object at 0x13868d7c0>, 'max_tiles': {'T': 1, 'C': inf, 'Z': 1, 'Y': 1024, 'X': 1024}, 'preserve_axes': False, 'chunked': False, 'max_workers': 0, 'compressor': {0: ZstdFilter(level=0), 1: ZstdFilter(level=0)}}
[2023-10-10 16:05:46,775] [ome_tiff] [image_metadata] [DEBUG] Image metadata: {'channels': [{'id': 'Channel:0:0', 'name': 'Channel 0', 'color': {'red': 255, 'green': 0, 'blue': 0, 'alpha': 255}}, {'id': 'Channel:0:1', 'name': 'Channel 1', 'color': {'red': 0, 'green': 255, 'blue': 0, 'alpha': 255}}, {'id': 'Channel:0:2', 'name': 'Channel 2', 'color': {'red': 0, 'green': 0, 'blue': 255, 'alpha': 255}}], 'physicalSizeX': 0.499, 'physicalSizeXUnit': 'µm', 'physicalSizeY': 0.499, 'physicalSizeYUnit': 'µm'}
[2023-10-10 16:05:46,775] [ome_tiff] [level_count] [DEBUG] Level count: 2
[2023-10-10 16:05:46,775] [base] [to_tiledb] [INFO] Converting level: 0
[2023-10-10 16:05:46,775] [ome_tiff] [axes] [DEBUG] Reader axes: Axes(dims='CYX')
[2023-10-10 16:05:46,776] [ome_tiff] [level_shape] [DEBUG] Level 0 shape: (3, 2967, 2220)
[2023-10-10 16:05:46,776] [ome_tiff] [axes] [DEBUG] Reader axes: Axes(dims='CYX')
[2023-10-10 16:05:46,776] [ome_tiff] [level_shape] [DEBUG] Level 0 shape: (3, 2967, 2220)
[2023-10-10 16:05:46,776] [ome_tiff] [level_dtype] [DEBUG] Level 0 dtype: uint8
```