### PR TITLE
Tiled writes during ingestion

### DIFF
--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -313,7 +313,7 @@ class ImageConverter:
         :param tiles: A mapping from dimension name (one of 'T', 'C', 'Z', 'Y', 'X') to
             the (maximum) tile for this dimension.
         :param tile_scale: The scaling factor applied to each tile during I/O.
-            LArger scale factors will result in less I/O operations.
+            Larger scale factors will result in less I/O operations.
         :param preserve_axes: If true, preserve the axes order of the original image.
         :param chunked: If true, convert one tile at a time instead of the whole image.
             **Note**: The OpenSlideConverter may not be 100% lossless with chunked=True

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -293,6 +293,7 @@ class ImageConverter:
         *,
         level_min: int = 0,
         tiles: Optional[Mapping[str, int]] = None,
+        tile_scale: int = 1,
         preserve_axes: bool = False,
         chunked: bool = False,
         max_workers: int = 0,
@@ -311,6 +312,8 @@ class ImageConverter:
             to convert all levels.
         :param tiles: A mapping from dimension name (one of 'T', 'C', 'Z', 'Y', 'X') to
             the (maximum) tile for this dimension.
+        :param tile_scale: The scaling factor applied to each tile during I/O.
+            LArger scale factors will result in less I/O operations.
         :param preserve_axes: If true, preserve the axes order of the original image.
         :param chunked: If true, convert one tile at a time instead of the whole image.
             **Note**: The OpenSlideConverter may not be 100% lossless with chunked=True
@@ -414,6 +417,7 @@ class ImageConverter:
                 reader=reader,
                 rw_group=rw_group,
                 max_tiles=max_tiles,
+                tile_scale=tile_scale,
                 preserve_axes=preserve_axes,
                 chunked=chunked,
                 max_workers=max_workers,
@@ -498,6 +502,7 @@ def _convert_level_to_tiledb(
     reader: ImageReader,
     rw_group: ReadWriteGroup,
     max_tiles: MutableMapping[str, int],
+    tile_scale: int,
     preserve_axes: bool,
     chunked: bool,
     max_workers: int,
@@ -566,8 +571,8 @@ def _convert_level_to_tiledb(
         # write image and metadata to TileDB array
         with open_bioimg(uri, "w") as out_array:
             out_array.meta.update(reader.level_metadata(level), level=level)
-            if chunked or max_workers:
-                inv_axes_mapper = axes_mapper.inverse
+            inv_axes_mapper = axes_mapper.inverse
+            if chunked:
 
                 def tile_to_tiledb(
                     level_tile: Tuple[slice, ...]
@@ -596,7 +601,25 @@ def _convert_level_to_tiledb(
                     ex.shutdown()
             else:
                 image = reader.level_image(level)
-                out_array[:] = axes_mapper.map_array(image)
+                ex = ThreadPoolExecutor(max_workers) if max_workers else None
+                mapper = getattr(ex, "map", map)
+
+                def write_to_tiledb(level_tile: Tuple[slice, ...]) -> None:
+                    source_tile = inv_axes_mapper.map_tile(level_tile)
+                    out_array[level_tile] = axes_mapper.map_array(image[source_tile])
+
+                for _ in tqdm(
+                    mapper(
+                        write_to_tiledb, iter_tiles(out_array.domain, scale=tile_scale)
+                    ),
+                    desc=f"Ingesting level {level}",
+                    total=num_tiles(out_array.domain, scale=tile_scale),
+                    unit="tiles",
+                ):
+                    # Find the global min-max values from all tiles
+                    pass
+                if ex:
+                    ex.shutdown()
 
                 compute_channel_minmax(
                     channel_min_max,

--- a/tiledb/bioimg/converters/tiles.py
+++ b/tiledb/bioimg/converters/tiles.py
@@ -4,22 +4,24 @@ from typing import Iterator, Tuple
 import tiledb
 
 
-def iter_tiles(domain: tiledb.Domain) -> Iterator[Tuple[slice, ...]]:
+def iter_tiles(domain: tiledb.Domain, scale: int = 1) -> Iterator[Tuple[slice, ...]]:
     """Generate all the non-overlapping tiles that cover the given TileDB domain."""
-    return it.product(*map(iter_slices, map(dim_range, domain)))
+    return it.product(
+        *map(iter_slices, map(dim_range, domain, [scale for _ in range(domain.ndim)]))
+    )
 
 
-def num_tiles(domain: tiledb.Domain) -> int:
+def num_tiles(domain: tiledb.Domain, scale: int = 1) -> int:
     """Compute the number of non-overlapping tiles that cover the given TileDB domain."""
     n = 1
     for dim in domain:
-        n *= len(dim_range(dim))
+        n *= len(dim_range(dim, scale=scale))
     return n
 
 
-def dim_range(dim: tiledb.Dim) -> range:
+def dim_range(dim: tiledb.Dim, scale: int = 1) -> range:
     """Get the range of the given tiledb dimension with step equal to the dimension tile."""
-    return range(int(dim.domain[0]), int(dim.domain[1]) + 1, dim.tile)
+    return range(int(dim.domain[0]), int(dim.domain[1]) + 1, dim.tile * scale)
 
 
 def iter_slices(r: range) -> Iterator[slice]:

--- a/tiledb/bioimg/converters/tiles.py
+++ b/tiledb/bioimg/converters/tiles.py
@@ -1,5 +1,6 @@
 import itertools as it
 from typing import Iterator, Tuple
+import numpy as np
 
 import tiledb
 
@@ -21,7 +22,7 @@ def num_tiles(domain: tiledb.Domain, scale: int = 1) -> int:
 
 def dim_range(dim: tiledb.Dim, scale: int = 1) -> range:
     """Get the range of the given tiledb dimension with step equal to the dimension tile."""
-    return range(int(dim.domain[0]), int(dim.domain[1]) + 1, dim.tile * scale)
+    return range(int(dim.domain[0]), int(dim.domain[1]) + 1, dim.tile.astype(np.int64) * scale)
 
 
 def iter_slices(r: range) -> Iterator[slice]:

--- a/tiledb/bioimg/converters/tiles.py
+++ b/tiledb/bioimg/converters/tiles.py
@@ -1,5 +1,6 @@
 import itertools as it
 from typing import Iterator, Tuple
+
 import numpy as np
 
 import tiledb
@@ -22,7 +23,9 @@ def num_tiles(domain: tiledb.Domain, scale: int = 1) -> int:
 
 def dim_range(dim: tiledb.Dim, scale: int = 1) -> range:
     """Get the range of the given tiledb dimension with step equal to the dimension tile."""
-    return range(int(dim.domain[0]), int(dim.domain[1]) + 1, dim.tile.astype(np.int64) * scale)
+    return range(
+        int(dim.domain[0]), int(dim.domain[1]) + 1, dim.tile.astype(np.int64) * scale
+    )
 
 
 def iter_slices(r: range) -> Iterator[slice]:

--- a/tiledb/bioimg/wrappers.py
+++ b/tiledb/bioimg/wrappers.py
@@ -17,6 +17,7 @@ def from_bioimg(
     *,
     verbose: bool = False,
     exclude_metadata: bool = False,
+    tile_scale: int = 1,
     **kwargs: Any,
 ) -> Type[ImageConverter]:
     """
@@ -37,6 +38,7 @@ def from_bioimg(
             output_path=dest,
             log=logger,
             exclude_metadata=exclude_metadata,
+            tile_scale=tile_scale,
             **kwargs,
         )
     elif converter is Converters.OMEZARR:
@@ -46,6 +48,7 @@ def from_bioimg(
             output_path=dest,
             log=logger,
             exclude_metadata=exclude_metadata,
+            tile_scale=tile_scale,
             **kwargs,
         )
     else:
@@ -55,6 +58,7 @@ def from_bioimg(
             output_path=dest,
             log=logger,
             exclude_metadata=exclude_metadata,
+            tile_scale=tile_scale,
             **kwargs,
         )
 


### PR DESCRIPTION
This PR adds tiled writes to TileDB arrays during non chunked ingestion. This change allows non chunked ingestion to run directly against a TileDB uri, fixing the `Entity too Large` constraint in REST. To avoid small writes and achieve network saturation the write domain tile can be scaled to write larger amounts of data at once.