### PR TITLE
Fix duplicate channel ID

### DIFF
--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -203,7 +203,7 @@ class OMETiffReader(ImageReader):
                     )
                     for i in range(channel["SamplesPerPixel"]):
                         channel_metadata = {
-                            "id": channel.get("ID", f"{idx}-{i}"),
+                            "id": f'{channel.get("ID", f"{idx}")}-{i}',
                             "name": channel.get("Name", f"Channel {idx}-{i}"),
                             "color": next(color_generator),
                         }


### PR DESCRIPTION
This PR fixes a bug where a duplicate channel ID will be written in case of an image a channel with multiple samples per pixel