### PR TITLE
Python version in CI, no-edit mode for installed dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
         choco install wget --no-progress
         wget https://github.com/openslide/openslide-winbuild/releases/download/v20221217/openslide-win64-20221217.zip
         7z x openslide-win64-20221217.zip -oD:\openslide-win64\
+        cd D:\openslide-win64\
+        set openslide_path=%cd%
+        echo %openslide_path%
       if: ${{ matrix.sys.os == 'windows-latest' }}
 
     - name: Run pre-commit hooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,13 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
         mkdir test_temp
-        C:\Users\runneradmin\micromamba\envs\test\python.exe -m pytest --basetemp=test_temp -v --cov=tiledb --cov-report=term-missing --durations=0 tests/
+        micromamba run -n test pytest --basetemp=test_temp -v --cov=tiledb --cov-report=term-missing --durations=0 tests/
       if: ${{ matrix.sys.os == 'windows-latest' }}
 
     - name: Run notebook examples
       run: |
         pip install opencv-python-headless matplotlib nbmake
-        pytest --nbmake examples
+        micromamba run -n test pytest --nbmake examples
 
     - name: Create Test Coverage Badge
       if: ${{ fromJSON(env.run_coverage) && matrix.sys.os == 'ubuntu-latest'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
 
     - name: Run pre-commit hooks
       shell: ${{ matrix.sys.shell }}
-      run: pre-commit run -a
+      run: |
+        pre-commit run -a
 
     - name: Install package
       shell: ${{ matrix.sys.shell }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,12 @@ jobs:
       if: ${{ matrix.sys.os == 'windows-latest' }}
 
     - name: Run pre-commit hooks
-      shell: ${{ matrix.sys.shell }}
+      shell: "bash -l {0}"
       run: |
         pre-commit run -a
 
     - name: Install package
-      shell: ${{ matrix.sys.shell }}
+      shell: "bash -l {0}"
       run: |
         pip install --no-cache-dir --upgrade tifffile "imagecodecs>=2023.7.10"
         pip install .[full]
@@ -79,7 +79,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      shell: ${{ matrix.sys.shell }}
+      shell: "bash -l {0}"
       run: |
         mkdir test_temp
         python -m pytest --basetemp=test_temp -v --cov=tiledb --cov-report=term-missing --durations=0 tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,17 @@ jobs:
       run: |
         choco install wget --no-progress
         wget https://github.com/openslide/openslide-winbuild/releases/download/v20221217/openslide-win64-20221217.zip
-        7z x openslide-win64-20221217.zip -oD:\openslide-win64\
+        7z x openslide-win64-20221217.zip -oD:\openslide\
+        mklink /D D:\openslide-win64\ D:\openslide\openslide-win64-20221217\
         cd D:\openslide-win64\
+        dir
         set openslide_path=%cd%
         echo %openslide_path%
       if: ${{ matrix.sys.os == 'windows-latest' }}
 
     - name: Run pre-commit hooks
-      shell: "bash -l {0}"
-      run: |
-        pre-commit run -a
+      run: | 
+        micromamba run -n test pre-commit run -a
 
     - name: Install package
       shell: "bash -l {0}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,9 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      shell: "bash -l {0}"
       run: |
         mkdir test_temp
-        python -m pytest --basetemp=test_temp -v --cov=tiledb --cov-report=term-missing --durations=0 tests/
+        C:\Users\runneradmin\micromamba\envs\test\python.exe -m pytest --basetemp=test_temp -v --cov=tiledb --cov-report=term-missing --durations=0 tests/
       if: ${{ matrix.sys.os == 'windows-latest' }}
 
     - name: Run notebook examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
       run: |
         choco install wget --no-progress
         wget https://github.com/openslide/openslide-winbuild/releases/download/v20221217/openslide-win64-20221217.zip
-        unzip ./openslide-win64-20221217.zip -d /usr/local/
-        mv /usr/local/openslide-win64-20221217/* /usr/local/
+        unzip ./openslide-win64-20221217.zip -d C:\python\openslide-win64-20171122\bin
+        mv /usr/local/openslide-win64-20221217/* C:\python\openslide-win64-20171122\bin
       if: matrix.os == 'windows-latest'
 
     - name: Run pre-commit hooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,18 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.sys.os }}
+    runs-on: ${{ matrix.sys.os }}
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        sys:
+          - { os: windows-latest, shell: 'cmd /C call {0}' }
+          - { os: ubuntu-latest,  shell: "bash -l {0}" }
       fail-fast: false
     defaults:
       run:
-        shell: bash -l {0}
+        shell: ${{ matrix.sys.shell }}
 
     env:
       run_coverage: ${{ github.ref == 'refs/heads/main' }}
@@ -35,20 +38,22 @@ jobs:
       run: |
         sudo apt install openslide-tools
         micromamba install openslide
-      if: matrix.os != 'windows-latest'
+        echo ${{ matrix.sys.os }}
+      if: ${{ matrix.sys.os != 'windows-latest' }}
 
     - name: Install openslide for Win 
       run: |
         choco install wget --no-progress
         wget https://github.com/openslide/openslide-winbuild/releases/download/v20221217/openslide-win64-20221217.zip
-        unzip ./openslide-win64-20221217.zip -d C:\python\openslide-win64-20171122\bin
-        mv /usr/local/openslide-win64-20221217/* C:\python\openslide-win64-20171122\bin
-      if: matrix.os == 'windows-latest'
+        7z x openslide-win64-20221217.zip -oD:\openslide-win64\
+      if: ${{ matrix.sys.os == 'windows-latest' }}
 
     - name: Run pre-commit hooks
+      shell: ${{ matrix.sys.shell }}
       run: pre-commit run -a
 
     - name: Install package
+      shell: ${{ matrix.sys.shell }}
       run: |
         pip install --no-cache-dir --upgrade tifffile "imagecodecs>=2023.7.10"
         pip install .[full]
@@ -59,18 +64,25 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
-        # This GITHUB_WORKSPACE is bydefault set to D: driver whereas pytest's tmp_dir 
-        # default is C: ,thus we create a temp_test folder for pytest's tmp_dir to run on D: as well 
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          pytest -v --cov=tiledb --cov-report=term-missing --durations=0 tests/ > coverage.txt
-          exit_code=$?
-          TEST_COVERAGE="$(grep '^TOTAL' coverage.txt | awk -v N=4 '{print $N}')"
-          echo "COVERAGE=$TEST_COVERAGE" >> $GITHUB_OUTPUT
-          exit $exit_code
-        else
-          mkdir test_temp
-          pytest --basetemp=test_temp -v --cov=tiledb --cov-report=term-missing --durations=0 tests/
-        fi
+        : # This GITHUB_WORKSPACE is bydefault set to D: driver whereas pytest's tmp_dir 
+        : # default is C: ,thus we create a temp_test folder for pytest's tmp_dir to run on D: as well 
+        pytest -v --cov=tiledb --cov-report=term-missing --durations=0 tests/ > coverage.txt
+        exit_code=$?
+        TEST_COVERAGE="$(grep '^TOTAL' coverage.txt | awk -v N=4 '{print $N}')"
+        echo "COVERAGE=$TEST_COVERAGE" >> $GITHUB_OUTPUT
+        exit $exit_code
+      if: ${{ matrix.sys.os != 'windows-latest' }}
+
+    - name: Run tests with coverage WINDOWS
+      id: stats-win
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      shell: ${{ matrix.sys.shell }}
+      run: |
+        mkdir test_temp
+        python -m pytest --basetemp=test_temp -v --cov=tiledb --cov-report=term-missing --durations=0 tests/
+      if: ${{ matrix.sys.os == 'windows-latest' }}
 
     - name: Run notebook examples
       run: |
@@ -78,7 +90,7 @@ jobs:
         pytest --nbmake examples
 
     - name: Create Test Coverage Badge
-      if: ${{ fromJSON(env.run_coverage) && matrix.os == 'ubuntu-latest'}}
+      if: ${{ fromJSON(env.run_coverage) && matrix.sys.os == 'ubuntu-latest'}}
       uses: schneegans/dynamic-badges-action@v1.1.0
       with:
         auth: ${{ secrets.COVERAGE_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Run notebook examples
       run: |
-        pip install opencv-python-headless matplotlib nbmake
+        micromamba run -n test pip install opencv-python-headless matplotlib nbmake
         micromamba run -n test pytest --nbmake examples
 
     - name: Create Test Coverage Badge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         environment-name: test
         cache-downloads: true
         create-args: >-
-          python=3.7
+          python=3.9
           pre-commit
           pytest-cov
           pytest-mock
@@ -50,8 +50,8 @@ jobs:
 
     - name: Install package
       run: |
-        pip install tifffile@git+https://github.com/TileDB-Inc/tifffile.git@gsa/python-3.7
-        pip install -e .[full]
+        pip install --no-cache-dir --upgrade tifffile "imagecodecs>=2023.7.10"
+        pip install .[full]
 
     - name: Run tests with coverage
       id: stats

--- a/tiledb/bioimg/converters/__init__.py
+++ b/tiledb/bioimg/converters/__init__.py
@@ -2,4 +2,4 @@ FMT_VERSION = 2
 DATASET_TYPE = "bioimg"
 
 # Windows use only
-WIN_OPENSLIDE_PATH = "D:/openslide-win64/bin"
+WIN_OPENSLIDE_PATH = r"D:\openslide-win64\bin"

--- a/tiledb/bioimg/converters/__init__.py
+++ b/tiledb/bioimg/converters/__init__.py
@@ -2,4 +2,4 @@ FMT_VERSION = 2
 DATASET_TYPE = "bioimg"
 
 # Windows use only
-WIN_OPENSLIDE_PATH = "D:\\openslide-win64\\bin"
+WIN_OPENSLIDE_PATH = "D:/openslide-win64/bin"

--- a/tiledb/bioimg/converters/__init__.py
+++ b/tiledb/bioimg/converters/__init__.py
@@ -2,4 +2,4 @@ FMT_VERSION = 2
 DATASET_TYPE = "bioimg"
 
 # Windows use only
-WIN_OPENSLIDE_PATH = "D:\\openslide-win64\\"
+WIN_OPENSLIDE_PATH = "D:\\openslide-win64\\bin"

--- a/tiledb/bioimg/converters/__init__.py
+++ b/tiledb/bioimg/converters/__init__.py
@@ -1,2 +1,5 @@
 FMT_VERSION = 2
 DATASET_TYPE = "bioimg"
+
+# Windows use only
+WIN_OPENSLIDE_PATH = r'C:\python\openslide-win64\bin'

--- a/tiledb/bioimg/converters/__init__.py
+++ b/tiledb/bioimg/converters/__init__.py
@@ -2,4 +2,4 @@ FMT_VERSION = 2
 DATASET_TYPE = "bioimg"
 
 # Windows use only
-WIN_OPENSLIDE_PATH = r'C:\python\openslide-win64\bin'
+WIN_OPENSLIDE_PATH = "D:\\openslide-win64\\"

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -1,10 +1,12 @@
 import logging
+import os
 from typing import Any, Dict, Optional, Sequence, Tuple, cast
-from . import WIN_OPENSLIDE_PATH
+
 import numpy as np
 
-import os
-if hasattr(os, 'add_dll_directory'):
+from . import WIN_OPENSLIDE_PATH
+
+if hasattr(os, "add_dll_directory"):
     # Python >= 3.8 on Windows
     with os.add_dll_directory(WIN_OPENSLIDE_PATH):
         import openslide as osd

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -1,8 +1,15 @@
 import logging
 from typing import Any, Dict, Optional, Sequence, Tuple, cast
-
+from . import WIN_OPENSLIDE_PATH
 import numpy as np
-import openslide as osd
+
+import os
+if hasattr(os, 'add_dll_directory'):
+    # Python >= 3.8 on Windows
+    with os.add_dll_directory(WIN_OPENSLIDE_PATH):
+        import openslide as osd
+else:
+    import openslide as osd
 
 from tiledb.cc import WebpInputFormat
 


### PR DESCRIPTION
This PR:

- Changes python version from 3.7 to 3.9 in CI
- Changes tifffile patch for python version 3.7
- Removes edit mode from tiledb installation.
- Adds `WIN_OPENSLIDE_PATH` for supporting os.add_dll_directory() needed for python >=3.8 on Windows.