### PR TITLE
Add error for incomplete ingestion of previous image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
       run: |
         pip install --no-cache-dir --upgrade tifffile "imagecodecs>=2023.7.10"
         pip install .[full]
-        pip install -e .[full]
 
     - name: Run tests with coverage
       id: stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
       run: |
         pip install --no-cache-dir --upgrade tifffile "imagecodecs>=2023.7.10"
         pip install .[full]
+        pip install -e .[full]
 
     - name: Run tests with coverage
       id: stats

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -143,7 +143,13 @@ def get_axes_mapper(
 def iter_levels_meta(group: tiledb.Group) -> Iterator[Mapping[str, Any]]:
     for o in group:
         with open_bioimg(o.uri) as array:
-            level = array.meta["level"]
+            try:
+                level = array.meta["level"]
+            except KeyError:
+                raise RuntimeError(
+                    "Key: 'level' not found in array metadata. Make sure that levels have been "
+                    "ingested correctly in any previous process for the same image."
+                )
             domain = array.schema.domain
             axes = "".join(domain.dim(dim_idx).name for dim_idx in range(domain.ndim))
             yield dict(level=level, name=f"l_{level}.tdb", axes=axes, shape=array.shape)

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -145,11 +145,11 @@ def iter_levels_meta(group: tiledb.Group) -> Iterator[Mapping[str, Any]]:
         with open_bioimg(o.uri) as array:
             try:
                 level = array.meta["level"]
-            except KeyError:
+            except KeyError as exc:
                 raise RuntimeError(
                     "Key: 'level' not found in array metadata. Make sure that levels have been "
                     "ingested correctly in any previous process for the same image."
-                )
+                ) from exc
             domain = array.schema.domain
             axes = "".join(domain.dim(dim_idx).name for dim_idx in range(domain.ndim))
             yield dict(level=level, name=f"l_{level}.tdb", axes=axes, shape=array.shape)


### PR DESCRIPTION
This PR:

- Adds a descriptive error in case of absence of `level` metadata key for a resolution layer.
- TileDB-Bioimaging supports incremental ingestion. In case of errors in previous runs for ingesting the specified image,
 the default behaviour is that the same levels are not ingested from scratch. If THOUGH the previous run did not ingest correctly the image or was abruptly terminated then the image levels might have been already partially ingested. This will create an issue in case of missing metadata in the following run. 
