### PR TITLE
Add jsonpickle to base dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 zarr = ["ome-zarr"]
 openslide = ["openslide-python"]
-tiff = ["tifffile", "imagecodecs", "jsonpickle"]
+tiff = ["tifffile", "imagecodecs"]
 cloud = ["tiledb-cloud"]
 
 full = sorted({*zarr, *openslide, *tiff, *cloud})
@@ -17,8 +17,8 @@ setuptools.setup(
         "pyeditdistance",
         "tiledb>=0.19",
         "tqdm",
-        "tifffile",
         "scikit-image",
+        "jsonpickle"
     ],
     extras_require={
         "zarr": zarr,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "tiledb>=0.19",
         "tqdm",
         "scikit-image",
-        "jsonpickle"
+        "jsonpickle",
     ],
     extras_require={
         "zarr": zarr,


### PR DESCRIPTION
This PR:

- Adds the `jsonpickle` in the required dependencies since now it is used also in the `converters/base.py` module.
- Removes it from being a dependency only for `tiff` builds.
- Removes `tifffile` for being a required dependency. Now it is a dependency only for `tiff` and `full` builds.