### PR TITLE
Fix ome-zarr channels metadata access

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,4 @@ repos:
     rev: v0.991
     hooks:
       - id: mypy
+        additional_dependencies: ['types-setuptools']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,3 @@ repos:
     rev: v0.991
     hooks:
       - id: mypy
-        additional_dependencies: ['types-setuptools']

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Breaking changes to the underlying data format and the API are to be expected.
     - OME-Tiff
     - Open-Slide
 
-### Ingestion from TileDB Groups of Arrays to:
+### Export from TileDB-Bioimaging Arrays to:
     - OME-Zarr
     - OME-Tiff
 
 ### Visualization Options
 
-- [TileDB Cloud](https://cloud.tiledb.com)
+- [TileDB Cloud](https://cloud.tiledb.com) includes a built-in, pyramidal multi-resolution viewer (log in to TileDB Cloud to see an example image preview [here](https://cloud.tiledb.com/biomedical-imaging/TileDB-Inc/dbb7dfcc-28b3-40e5-916f-6509a666d950/preview))
 - Napari: https://github.com/TileDB-Inc/napari-tiledb-bioimg
 
 ## Quick Installation

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-zarr = ["ome-zarr"]
+zarr = ["ome-zarr>=0.9.0"]
 openslide = ["openslide-python"]
 tiff = ["tifffile", "imagecodecs"]
 cloud = ["tiledb-cloud"]

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 import logging
+from distutils.version import StrictVersion
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, cast
 
 import numpy
 import numpy as np
+import pkg_resources
 import zarr
 from numcodecs import Blosc
 from ome_zarr.reader import OMERO, Multiscales, Reader, ZarrLocation
@@ -17,9 +19,6 @@ from .. import WHITE_RGB
 from ..helpers import get_logger_wrapper, get_rgba
 from .axes import Axes
 from .base import ImageConverter, ImageReader, ImageWriter
-
-import pkg_resources
-from distutils.version import StrictVersion
 
 # Check the version of a package
 ome_zarr_version = pkg_resources.get_distribution("ome_zarr").version
@@ -60,7 +59,7 @@ class OMEZarrReader(ImageReader):
         channels = ()
         if self._omero:
             # ome-zarr 0.9.0 changed the spec
-            if StrictVersion(ome_zarr_version) > StrictVersion('0.8.3'):
+            if StrictVersion(ome_zarr_version) > StrictVersion("0.8.3"):
                 channels = self._omero.node.metadata.get("channel_names", ())
             else:
                 channels = self._omero.node.metadata.get("name", ())

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import json
 import logging
-from distutils.version import StrictVersion
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, cast
 
 import numpy
 import numpy as np
-import pkg_resources
 import zarr
 from numcodecs import Blosc
 from ome_zarr.reader import OMERO, Multiscales, Reader, ZarrLocation
@@ -19,9 +17,6 @@ from .. import WHITE_RGB
 from ..helpers import get_logger_wrapper, get_rgba
 from .axes import Axes
 from .base import ImageConverter, ImageReader, ImageWriter
-
-# Check the version of a package
-ome_zarr_version = pkg_resources.get_distribution("ome_zarr").version
 
 
 class OMEZarrReader(ImageReader):
@@ -56,14 +51,11 @@ class OMEZarrReader(ImageReader):
 
     @property
     def channels(self) -> Sequence[str]:
-        channels = ()
-        if self._omero:
-            # ome-zarr 0.9.0 changed the spec
-            if StrictVersion(ome_zarr_version) > StrictVersion("0.8.3"):
-                channels = self._omero.node.metadata.get("channel_names", ())
-            else:
-                channels = self._omero.node.metadata.get("name", ())
-        return channels
+        return (
+            tuple(self._omero.node.metadata.get("channel_names", ()))
+            if self._omero
+            else ()
+        )
 
     @property
     def webp_format(self) -> WebpInputFormat:


### PR DESCRIPTION
This PR:

- Adds version condition for accessing the `omero` channels metadata due to changes in `ome-zarr` in memory specification. The latest `0.9.0` release moves channels' name metadata under the key `"channel_names"` when before that the key was `name`.
- Require minimum version `0.9.0` for `ome-zarr`