### PR TITLE
Pushing VFS down to converters

### DIFF
--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -15,15 +15,11 @@ from tiledb.bioimg.openslide import TileDBOpenSlide
 from tiledb.cc import WebpInputFormat
 
 
-@pytest.mark.parametrize("open_fileobj", [False, True])
-def test_ome_tiff_converter(tmp_path, open_fileobj):
+def test_ome_tiff_converter(tmp_path):
     input_path = str(get_path("CMU-1-Small-Region.ome.tiff"))
     output_path = str(tmp_path)
-    if open_fileobj:
-        with open(input_path, "rb") as f:
-            OMETiffConverter.to_tiledb(f, output_path)
-    else:
-        OMETiffConverter.to_tiledb(input_path, output_path)
+
+    OMETiffConverter.to_tiledb(input_path, output_path)
 
     with TileDBOpenSlide(output_path) as t:
         assert len(tiledb.Group(output_path)) == t.level_count == 2

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -26,7 +26,7 @@ from tiledb.cc import WebpInputFormat
     ],
 )
 def test_openslide_converter(tmp_path, preserve_axes, chunked, max_workers, compressor):
-    input_path = get_path("CMU-1-Small-Region.svs")
+    input_path = str(get_path("CMU-1-Small-Region.svs"))
     output_path = str(tmp_path)
     OpenSlideConverter.to_tiledb(
         input_path,
@@ -80,7 +80,7 @@ def test_openslide_converter(tmp_path, preserve_axes, chunked, max_workers, comp
 
 @pytest.mark.parametrize("preserve_axes", [False, True])
 def test_openslide_converter_group_metadata(tmp_path, preserve_axes):
-    input_path = get_path("CMU-1-Small-Region.svs")
+    input_path = str(get_path("CMU-1-Small-Region.svs"))
     output_path = str(tmp_path)
     OpenSlideConverter.to_tiledb(input_path, output_path, preserve_axes=preserve_axes)
 

--- a/tests/integration/converters/test_scaler.py
+++ b/tests/integration/converters/test_scaler.py
@@ -13,25 +13,23 @@ def test_scaler(tmp_path, scale_factors, chunked, max_workers, progressive):
     ground_path = str(tmp_path / "ground")
     test_path = str(tmp_path / "test")
 
-    with open(input_path, "rb") as f:
-        OMETiffConverter.to_tiledb(
-            f,
-            ground_path,
-            pyramid_kwargs={"scale_factors": scale_factors},
-        )
+    OMETiffConverter.to_tiledb(
+        input_path,
+        ground_path,
+        pyramid_kwargs={"scale_factors": scale_factors},
+    )
 
-    with open(input_path, "rb") as f:
-        OMETiffConverter.to_tiledb(
-            f,
-            test_path,
-            pyramid_kwargs={
-                "scale_factors": scale_factors,
-                "chunked": chunked,
-                "progressive": progressive,
-                "order": 1,
-                "max_workers": max_workers,
-            },
-        )
+    OMETiffConverter.to_tiledb(
+        input_path,
+        test_path,
+        pyramid_kwargs={
+            "scale_factors": scale_factors,
+            "chunked": chunked,
+            "progressive": progressive,
+            "order": 1,
+            "max_workers": max_workers,
+        },
+    )
 
     with TileDBOpenSlide(ground_path) as ground, TileDBOpenSlide(test_path) as test:
         assert ground.level_count == test.level_count

--- a/tests/integration/test_wrappers.py
+++ b/tests/integration/test_wrappers.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from tests import get_path
@@ -19,7 +21,7 @@ from tiledb.bioimg.converters.openslide import OpenSlideConverter
     ],
 )
 def test_from_bioimg_wrapper(tmp_path, converter, file_path):
-    input_path = get_path(file_path)
+    input_path = str(get_path(file_path))
     output_path = str(tmp_path)
     output_path_round = str(tmp_path) + "/roundtrip"
     if converter == Converters.OMETIFF:
@@ -32,7 +34,7 @@ def test_from_bioimg_wrapper(tmp_path, converter, file_path):
         with pytest.raises(NotImplementedError):
             to_bioimg(output_path, output_path_round, converter=converter)
     else:
-        input_path = input_path / str(0)
+        input_path = os.path.join(input_path, str(0))
         rfromtype = from_bioimg(input_path, output_path, converter=converter)
         rtotype = to_bioimg(output_path, output_path_round, converter=converter)
         assert rfromtype == rtotype == OMEZarrConverter

--- a/tiledb/bioimg/converters/__init__.py
+++ b/tiledb/bioimg/converters/__init__.py
@@ -1,5 +1,5 @@
 FMT_VERSION = 2
 DATASET_TYPE = "bioimg"
-
+DEFAULT_SCRATCH_SPACE = "/dev/shm"
 # Windows use only
 WIN_OPENSLIDE_PATH = r"D:\openslide-win64\bin"

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -304,45 +304,45 @@ class ImageConverter:
         pyramid_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> Type[ImageConverter]:
         """
-        Convert an image to a TileDB Group of Arrays, one per level.
+                Convert an image to a TileDB Group of Arrays, one per level.
 
-        :param source: path to the input image or ImageReader object
-        :param output_path: path to the TileDB group of arrays
-        :param level_min: minimum level of the image to be converted. By default set to 0
-            to convert all levels.
-        :param tiles: A mapping from dimension name (one of 'T', 'C', 'Z', 'Y', 'X') to
-            the (maximum) tile for this dimension.
-        :param tile_scale: The scaling factor applied to each tile during I/O.
-            Larger scale factors will result in less I/O operations.
-        :param preserve_axes: If true, preserve the axes order of the original image.
-        :param chunked: If true, convert one tile at a time instead of the whole image.
-            **Note**: The OpenSlideConverter may not be 100% lossless with chunked=True
-            for levels>0, even though the converted images look visually identical to the
-            original ones.
-        :param max_workers: Maximum number of threads that can be used for conversion.
-            Applicable only if chunked=True.
-        :param exclude_metadata: If true, drop original metadata of the images and exclude them from being ingested.
-        :param compressor: TileDB compression filter mapping for each level
-        :param log: verbose logging, defaults to None. Allows passing custom logging.Logger or boolean.
-            If None or bool=False it initiates an INFO level logging. If bool=True then a logger is instantiated in
-            DEBUG logging level.
-        :param reader_kwargs: Keyword arguments passed to the _ImageReaderType constructor. Allows passing configuration
-            parameters like tiledb.Config or/and tiledb.Ctx.
-        :param pyramid_kwargs: Keyword arguments passed to the scaler constructor for
-            generating downsampled versions of the base level. Valid keyword arguments are:
-            scale_factors (Required): The downsampling factor for each level
-            scale_axes (Optional): Default "XY". The axes which will be downsampled
-            chunked (Optional): Default False. If true the image is split into chunks and
-                each one is independently downsampled. If false the entire image is
-                downsampled at once, but it requires more memory.
-            progressive (Optional): Default False. If true each downsampled image is
-                generated using the previous level. If false for every downsampled image
-                the level_min is used, but it requires more memory.
-            order (Optional): Default 1. The order of the spline interpolation. The order
-                has to be in the range 0-5. See `skimage.transform.warp` for detail.
-            max_workers (Optional): Default None. The maximum number of workers for
-                chunked downsampling. If None, it will default to the number of processors
-                on the machine, multiplied by 5.
+                :param source: path to the input image or ImageReader object
+                :param output_path: path to the TileDB group of arrays
+                :param level_min: minimum level of the image to be converted. By default set to 0
+                    to convert all levels.
+                :param tiles: A mapping from dimension name (one of 'T', 'C', 'Z', 'Y', 'X') to
+                    the (maximum) tile for this dimension.
+                :param tile_scale: The scaling factor applied to each tile during I/O.
+                    Larger scale factors will result in less I/O operations.
+                :param preserve_axes: If true, preserve the axes order of the original image.
+                :param chunked: If true, convert one tile at a time instead of the whole image.
+                    **Note**: The OpenSlideConverter may not be 100% lossless with chunked=True
+                    for levels>0, even though the converted images look visually identical to the
+                    original ones.
+                :param max_workers: Maximum number of threads that can be used for conversion.
+                    Applicable only if chunked=True.
+                :param exclude_metadata: If true, drop original metadata of the images and exclude them from being ingested.
+                :param compressor: TileDB compression filter mapping for each level
+                :param log: verbose logging, defaults to None. Allows passing custom logging.Logger or boolean.
+                    If None or bool=False it initiates an INFO level logging. If bool=True then a logger is instantiated in
+                    DEBUG logging level.
+                :param reader_kwargs: Keyword arguments passed to the _ImageReaderType constructor. Allows passing configuration
+                    parameters like tiledb.Config or/and tiledb.Ctx.
+        See Also        :param pyramid_kwargs: Keyword arguments passed to the scaler constructor for
+                    generating downsampled versions of the base level. Valid keyword arguments are:
+                    scale_factors (Required): The downsampling factor for each level
+                    scale_axes (Optional): Default "XY". The axes which will be downsampled
+                    chunked (Optional): Default False. If true the image is split into chunks and
+                        each one is independently downsampled. If false the entire image is
+                        downsampled at once, but it requires more memory.
+                    progressive (Optional): Default False. If true each downsampled image is
+                        generated using the previous level. If false for every downsampled image
+                        the level_min is used, but it requires more memory.
+                    order (Optional): Default 1. The order of the spline interpolation. The order
+                        has to be in the range 0-5. See `skimage.transform.warp` for detail.
+                    max_workers (Optional): Default None. The maximum number of workers for
+                        chunked downsampling. If None, it will default to the number of processors
+                        on the machine, multiplied by 5.
         """
 
         if log:

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -58,7 +58,15 @@ DEFAULT_SCRATCH_SPACE = "/dev/shm"
 
 class ImageReader(ABC):
     @abstractmethod
-    def __init__(self, input_path: str, logger: logging.Logger, **kwargs: Any):
+    def __init__(
+        self,
+        input_path: str,
+        *,
+        logger: Optional[logging.Logger],
+        config: Optional[tiledb.Config] = None,
+        ctx: Optional[tiledb.Ctx] = None,
+        **kwargs: Any,
+    ):
         """Initialize this ImageReader"""
 
     def __enter__(self) -> ImageReader:
@@ -359,7 +367,7 @@ class ImageConverter:
             reader = source
         elif cls._ImageReaderType is not None:
             reader = cls._ImageReaderType(
-                source, logger, **reader_kwargs if reader_kwargs else {}
+                source, logger=logger, **reader_kwargs if reader_kwargs else {}
             )
         else:
             raise NotImplementedError(f"{cls} does not support importing")

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -326,7 +326,8 @@ class ImageConverter:
         :param log: verbose logging, defaults to None. Allows passing custom logging.Logger or boolean.
             If None or bool=False it initiates an INFO level logging. If bool=True then a logger is instantiated in
             DEBUG logging level.
-        :param reader_kwargs: Keyword arguments passed to the _ImageReaderType constructor.
+        :param reader_kwargs: Keyword arguments passed to the _ImageReaderType constructor. Allows passing configuration
+            parameters like tiledb.Config or/and tiledb.Ctx.
         :param pyramid_kwargs: Keyword arguments passed to the scaler constructor for
             generating downsampled versions of the base level. Valid keyword arguments are:
             scale_factors (Required): The downsampling factor for each level

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -7,8 +7,9 @@ import jsonpickle as json
 import numpy as np
 import tifffile
 
-from tiledb.cc import WebpInputFormat
 from tiledb import VFS, Config, Ctx
+from tiledb.cc import WebpInputFormat
+
 from .. import ATTR_NAME, EXPORT_TILE_SIZE, WHITE_RGBA
 from ..helpers import get_decimal_from_rgba, get_logger_wrapper, get_rgba, iter_color
 from .axes import Axes
@@ -37,7 +38,7 @@ class OMETiffReader(ImageReader):
         # Use VFS for all paths local or remote for reading the input image
         self._input_path = input_path
         self._vfs = VFS(config=config, ctx=ctx)
-        self._vfs_fh = self._vfs.open(input_path, mode='rb')
+        self._vfs_fh = self._vfs.open(input_path, mode="rb")
         self._tiff = tifffile.TiffFile(self._vfs_fh)
         # XXX ignore all but the first series
         self._series = self._tiff.series[0]

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -9,6 +9,7 @@ import tifffile
 
 from tiledb import VFS, Config, Ctx
 from tiledb.cc import WebpInputFormat
+from tiledb.highlevel import _get_ctx
 
 from .. import ATTR_NAME, EXPORT_TILE_SIZE, WHITE_RGBA
 from ..helpers import get_decimal_from_rgba, get_logger_wrapper, get_rgba, iter_color
@@ -21,6 +22,7 @@ class OMETiffReader(ImageReader):
     def __init__(
         self,
         input_path: str,
+        *,
         logger: Optional[logging.Logger] = None,
         config: Optional[Config] = None,
         ctx: Optional[Ctx] = None,
@@ -37,7 +39,9 @@ class OMETiffReader(ImageReader):
 
         # Use VFS for all paths local or remote for reading the input image
         self._input_path = input_path
-        self._vfs = VFS(config=config, ctx=ctx)
+        self._ctx = _get_ctx(ctx, config)
+        self._cfg = self._ctx.config()
+        self._vfs = VFS(config=self._cfg, ctx=self._ctx)
         self._vfs_fh = self._vfs.open(input_path, mode="rb")
         self._tiff = tifffile.TiffFile(self._vfs_fh)
         # XXX ignore all but the first series

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -25,6 +25,7 @@ class OMEZarrReader(ImageReader):
     def __init__(
         self,
         input_path: str,
+        *,
         logger: Optional[logging.Logger] = None,
         config: Optional[Config] = None,
         ctx: Optional[Ctx] = None,

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -11,11 +11,11 @@ from numcodecs import Blosc
 from ome_zarr.reader import OMERO, Multiscales, Reader, ZarrLocation
 from ome_zarr.writer import write_multiscale
 
-from tiledb.cc import WebpInputFormat
 from tiledb import Config, Ctx
+from tiledb.cc import WebpInputFormat
 
 from .. import WHITE_RGB
-from ..helpers import get_logger_wrapper, get_rgba
+from ..helpers import get_logger_wrapper, get_rgba, translate_config_to_s3fs
 from .axes import Axes
 from .base import ImageConverter, ImageReader, ImageWriter
 
@@ -24,20 +24,20 @@ class OMEZarrReader(ImageReader):
     def __init__(
         self,
         input_path: str,
+        logger: Optional[logging.Logger] = None,
         config: Optional[Config] = None,
         ctx: Optional[Ctx] = None,
-        logger: Optional[logging.Logger] = None,
     ):
         """
         OME-Zarr image reader
-
         :param input_path: The path to the Zarr image
         """
         self._logger = get_logger_wrapper(False) if not logger else logger
-        storage_options = {'key': config.get('vfs.s3.access_aws_access_key_id', None),
-                           'secret': config.get('vfs.s3.aws_secret_access_key', None)}
-        store = zarr.storage.FSStore(input_path, check=True, create=True, **storage_options)
-        self._root_node = next(Reader(ZarrLocation(input_path))())
+        storage_options = translate_config_to_s3fs(config, ctx)
+        input_fh = zarr.storage.FSStore(
+            input_path, check=True, create=True, **storage_options
+        )
+        self._root_node = next(Reader(ZarrLocation(input_fh))())
         self._multiscales = cast(Multiscales, self._root_node.load(Multiscales))
         self._omero = cast(Optional[OMERO], self._root_node.load(OMERO))
 

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -13,6 +13,7 @@ from ome_zarr.writer import write_multiscale
 
 from tiledb import Config, Ctx
 from tiledb.cc import WebpInputFormat
+from tiledb.highlevel import _get_ctx
 
 from .. import WHITE_RGB
 from ..helpers import get_logger_wrapper, get_rgba, translate_config_to_s3fs
@@ -33,7 +34,9 @@ class OMEZarrReader(ImageReader):
         :param input_path: The path to the Zarr image
         """
         self._logger = get_logger_wrapper(False) if not logger else logger
-        storage_options = translate_config_to_s3fs(config, ctx)
+        self._ctx = _get_ctx(ctx, config)
+        self._cfg = self._ctx.config()
+        storage_options = translate_config_to_s3fs(self._cfg)
         input_fh = zarr.storage.FSStore(
             input_path, check=True, create=True, **storage_options
         )

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -27,6 +27,7 @@ class OpenSlideReader(ImageReader):
     def __init__(
         self,
         input_path: str,
+        *,
         logger: Optional[logging.Logger] = None,
         config: Optional[Config] = None,
         ctx: Optional[Ctx] = None,
@@ -40,11 +41,12 @@ class OpenSlideReader(ImageReader):
         self._ctx = _get_ctx(ctx, config)
         self._cfg = self._ctx.config()
         self._logger = get_logger_wrapper(False) if not logger else logger
-        resolved_path = input_path
         if is_remote_protocol(input_path):
             resolved_path = cache_filepath(
                 input_path, config, ctx, self._logger, scratch_space
             )
+        else:
+            resolved_path = input_path
         self._osd = osd.OpenSlide(resolved_path)
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -4,13 +4,13 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Iterator, Mapping, MutableMapping, Sequence, Tuple
+from typing import Any, Dict, Iterator, Mapping, MutableMapping, Sequence, Tuple, Optional
 from urllib.parse import urlparse
 
 import numpy as np
 
 import tiledb
-from tiledb import Config
+from tiledb import Config, Ctx
 from tiledb.cc import WebpInputFormat
 
 from . import ATTR_NAME
@@ -19,22 +19,23 @@ from .version import version_tuple
 
 
 class ReadWriteGroup:
-    def __init__(self, uri: str):
+    def __init__(self, uri: str, ctx: Optional[Ctx] = None):
         parsed_uri = urlparse(uri)
         # normalize uri if it's a local path (e.g. ../..foo/bar)
 
         # Windows paths produce single letter scheme matching the drive letter
         # Unix absolute path produce an empty scheme
+        self._ctx = ctx
         if len(parsed_uri.scheme) < 2 or parsed_uri.scheme == "file":
             uri = str(Path(parsed_uri.path).resolve()).replace("\\", "/")
-        if tiledb.object_type(uri) != "group":
-            tiledb.group_create(uri)
+        if tiledb.object_type(uri, ctx=ctx) != "group":
+            tiledb.group_create(uri, ctx=ctx)
         self._uri = uri if uri.endswith("/") else uri + "/"
         self._is_cloud = parsed_uri.scheme == "tiledb"
 
     def __enter__(self) -> ReadWriteGroup:
-        self.r_group = tiledb.Group(self._uri, "r")
-        self.w_group = tiledb.Group(self._uri, "w")
+        self.r_group = tiledb.Group(self._uri, "r", ctx=self._ctx)
+        self.w_group = tiledb.Group(self._uri, "w", ctx=self._ctx)
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
@@ -49,7 +50,7 @@ class ReadWriteGroup:
             uri = os.path.join(self._uri, name).replace("\\", "/")
 
             if not tiledb.array_exists(uri):
-                tiledb.Array.create(uri, schema)
+                tiledb.Array.create(uri, schema, ctx=self._ctx)
                 create = True
             else:
                 # The array exists, but it's not added as group member with the given name.
@@ -78,10 +79,10 @@ class ReadWriteGroup:
 
 
 def open_bioimg(
-    uri: str, mode: str = "r", attr: str = ATTR_NAME, config: Config = None
+    uri: str, mode: str = "r", attr: str = ATTR_NAME, config: Config = None, ctx: Optional[Ctx] = None
 ) -> tiledb.Array:
     return tiledb.open(
-        uri, mode=mode, attr=attr if mode == "r" else None, config=config
+        uri, mode=mode, attr=attr if mode == "r" else None, config=config, ctx=ctx
     )
 
 
@@ -140,9 +141,9 @@ def get_axes_mapper(
     return axes_mapper, dim_names, tiles
 
 
-def iter_levels_meta(group: tiledb.Group) -> Iterator[Mapping[str, Any]]:
+def iter_levels_meta(group: tiledb.Group, config: Config = None, ctx: Optional[Ctx] = None) -> Iterator[Mapping[str, Any]]:
     for o in group:
-        with open_bioimg(o.uri) as array:
+        with open_bioimg(o.uri, config=config, ctx=ctx) as array:
             try:
                 level = array.meta["level"]
             except KeyError as exc:

--- a/tiledb/bioimg/openslide.py
+++ b/tiledb/bioimg/openslide.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from operator import attrgetter
-from typing import Any, Mapping, MutableMapping, Sequence, Tuple, Union, Optional
+from typing import Any, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -31,8 +31,14 @@ class TileDBOpenSlide:
         )
         return cls(uri, attr=attr)
 
-    def __init__(self, uri: str, *, attr: str = ATTR_NAME, config: Config = None, ctx: Optional[Ctx] = None,
-):
+    def __init__(
+        self,
+        uri: str,
+        *,
+        attr: str = ATTR_NAME,
+        config: Config = None,
+        ctx: Optional[Ctx] = None,
+    ):
         """Open this TileDBOpenSlide.
 
         :param uri: uri of a tiledb.Group containing the image
@@ -42,7 +48,9 @@ class TileDBOpenSlide:
         pixel_depth = dict(json.loads(pixel_depth)) if pixel_depth else {}
         self._levels = sorted(
             (
-                TileDBOpenSlideLevel(o.uri, pixel_depth, attr=attr, config=config, ctx=ctx)
+                TileDBOpenSlideLevel(
+                    o.uri, pixel_depth, attr=attr, config=config, ctx=ctx
+                )
                 for o in self._group
             ),
             key=attrgetter("level"),

--- a/tiledb/bioimg/openslide.py
+++ b/tiledb/bioimg/openslide.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from operator import attrgetter
-from typing import Any, Mapping, MutableMapping, Sequence, Tuple, Union
+from typing import Any, Mapping, MutableMapping, Sequence, Tuple, Union, Optional
 
 import numpy as np
 
@@ -14,7 +14,7 @@ except ImportError:
 import json
 
 import tiledb
-from tiledb import Config
+from tiledb import Config, Ctx
 
 from . import ATTR_NAME
 from .converters.axes import Axes
@@ -31,18 +31,18 @@ class TileDBOpenSlide:
         )
         return cls(uri, attr=attr)
 
-    def __init__(self, uri: str, *, attr: str = ATTR_NAME, config: Config = None):
+    def __init__(self, uri: str, *, attr: str = ATTR_NAME, config: Config = None, ctx: Optional[Ctx] = None,
+):
         """Open this TileDBOpenSlide.
 
         :param uri: uri of a tiledb.Group containing the image
         """
-        self._config = config
-        self._group = tiledb.Group(uri, config=config)
+        self._group = tiledb.Group(uri, config=config, ctx=ctx)
         pixel_depth = self._group.meta.get("pixel_depth", "")
         pixel_depth = dict(json.loads(pixel_depth)) if pixel_depth else {}
         self._levels = sorted(
             (
-                TileDBOpenSlideLevel(o.uri, pixel_depth, attr=attr, config=config)
+                TileDBOpenSlideLevel(o.uri, pixel_depth, attr=attr, config=config, ctx=ctx)
                 for o in self._group
             ),
             key=attrgetter("level"),
@@ -170,9 +170,9 @@ class TileDBOpenSlideLevel:
         *,
         attr: str,
         config: Config = None,
+        ctx: Optional[Ctx] = None,
     ):
-        self._config = config
-        self._tdb = open_bioimg(uri, attr=attr, config=config)
+        self._tdb = open_bioimg(uri, attr=attr, config=config, ctx=ctx)
         self._pixel_depth = pixel_depth.get(str(self.level), 1)
 
     @property


### PR DESCRIPTION
This PR:

- Pushes down the VFS inside the converters allowing passing of config and context for accessing input images directly from S3. 


Usage:
```bash
from tiledb.bioimg import from_bioimg
from_bioimg(src='s3://tiledb-bioimg/local_testing/CMU-1-Small-Region-rgb.ome.tiff', dest='./tests/data/cmu-rgb-vfs.tdb', reader_kwargs={"config":tiledb.Config({})}
>>Ingesting level 0: 100%|██████████| 9/9 [00:00<00:00, 47.70tiles/s]
>>Ingesting level 1: 100%|██████████| 1/1 [00:00<00:00, 47.95tiles/s]

---
from tiledb.bioimg.openslide import TileDBOpenSlide
slide = TileDBOpenSlide('s3://tiledb-bioimg/local_testing/CMU-1-Small-Region-rgb.ome.tiff', config=tiledb.Config({}))
slide.levels
>>Out[9]: (0, 1, 2, 3)

```

It will resolve related story [sc-25684] [sc-43577]