### PR TITLE
Validating ingestion of levels to make ingestion idempotent

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
+import random
 import numpy as np
 from skimage.metrics import structural_similarity
 
 import tiledb
 from tiledb.bioimg import ATTR_NAME
 from tiledb.cc import WebpInputFormat
+from tiledb.bioimg.helpers import merge_ned_ranges
 
 DATA_DIR = Path(__file__).parent / "data"
 
@@ -80,3 +82,32 @@ def get_path(uri):
 def assert_image_similarity(im1, im2, min_threshold=0.95, channel_axis=-1, win_size=11):
     s = structural_similarity(im1, im2, channel_axis=channel_axis, win_size=win_size)
     assert s >= min_threshold, (s, min_threshold, im1.shape)
+
+
+def generate_test_case(num_axes, num_ranges, max_value):
+    """
+    Generate a test case with a given number of axes and ranges.
+
+    Parameters:
+    num_axes (int): Number of axes.
+    num_ranges (int): Number of ranges.
+    max_value (int): Maximum value for range endpoints.
+
+    Returns:
+    tuple: A tuple containing the generated input and the expected output.
+    """
+    input_ranges = []
+
+    for _ in range(num_ranges):
+        ranges = []
+        for _ in range(num_axes):
+            start = random.randint(0, max_value - 1)
+            end = random.randint(start, max_value)
+            ranges.append((start, end))
+        input_ranges.append(tuple(ranges))
+
+    input_ranges = tuple(input_ranges)
+
+    expected_output = merge_ned_ranges(input_ranges)
+
+    return input_ranges, expected_output

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -7,7 +7,10 @@ from tiledb.bioimg.helpers import (
     get_pixel_depth,
     get_rgba,
     iter_color,
+    merge_ned_ranges,
 )
+
+from .. import generate_test_case
 
 
 def test_color_iterator():
@@ -44,3 +47,12 @@ def test_get_pixel_depth():
     with pytest.raises(ValueError) as err:
         get_pixel_depth(webp_filter)
         assert "Invalid WebpInputFormat" in str(err)
+
+
+@pytest.mark.parametrize(
+    "num_axes, num_ranges, max_value",
+    [(5, 10, 100), (3, 20, 50), (4, 15, 200), (6, 25, 300)],
+)
+def test_validate_ingestion(num_axes, num_ranges, max_value):
+    input_ranges, expected_output = generate_test_case(num_axes, num_ranges, max_value)
+    assert merge_ned_ranges(input_ranges) == expected_output

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -46,6 +46,7 @@ from ..helpers import (
     iter_pixel_depths_meta,
     open_bioimg,
     resolve_path,
+    validate_ingestion,
 )
 from ..openslide import TileDBOpenSlide
 from ..version import version as PKG_VERSION
@@ -577,7 +578,8 @@ def _convert_level_to_tiledb(
 
     # get or create TileDB array uri
     uri, created = rw_group.get_or_create(f"l_{level}.tdb", schema)
-    if created:
+
+    if created or not validate_ingestion(uri):
         # write image and metadata to TileDB array
         with open_bioimg(uri, "w") as out_array:
             out_array.meta.update(reader.level_metadata(level), level=level)


### PR DESCRIPTION
This PR:

- Introduces a helper function `validate_ingestion` that compares the `ned` and the number of fragments of each level with the `array schema` domains of each dimension to impose a correctness check.
- Till now once a level was created we were assuming its correctness without any check in order to support `incremental ingestion`. This logic however contradicted with the retry policy imposed during batch ingestion in taskgraph environment and led to missing metadata and errors like the following:

```python
 File "tiledb/libmetadata.pyx", line 327, in tiledb.libtiledb.Metadata.__getitem__
KeyError: 'level'
```
-  Tests the validation function's internals in unittest.