### PR TITLE
Remove pinned scikit since 0.24.0 was released

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
       shell: "bash -l {0}"
       run: |
         pip install --no-cache-dir --upgrade tifffile "imagecodecs>=2023.7.10"
-        pip install scikit-image==0.24.0rc1
         pip install .[full]
 
     - name: Run tests with coverage


### PR DESCRIPTION
This PR:

- Removes the pin in CI for scikit-image after the release of version [`0.24.0`](https://pypi.org/project/scikit-image/0.24.0/) that supports `numpy==2.0`