### PR TITLE
Change Openslide Drive Path for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ jobs:
 
     env:
       run_coverage: ${{ github.ref == 'refs/heads/main' }}
-    
+
+    outputs:
+      coverage: ${{ steps.stats.outputs.coverage }}
+
     steps:
     - uses: actions/checkout@v2
 
@@ -74,7 +77,7 @@ jobs:
         pytest -v --cov=tiledb --cov-report=term-missing --durations=0 tests/ > coverage.txt
         exit_code=$?
         TEST_COVERAGE="$(grep '^TOTAL' coverage.txt | awk -v N=4 '{print $N}')"
-        echo "COVERAGE=$TEST_COVERAGE" >> $GITHUB_OUTPUT
+        echo "coverage=$TEST_COVERAGE" >> $GITHUB_OUTPUT
         exit $exit_code
       if: ${{ matrix.sys.os != 'windows-latest' }}
 
@@ -101,6 +104,6 @@ jobs:
         gistID: 32d48185733a4e7375e80e3e35fab452
         filename: gist_bioimg.json
         label: Test Coverage
-        message: ${{ steps.stats.outputs.COVERAGE }}
+        message: ${{ steps.stats.outputs.coverage }}
         color: green
         namedLogo: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
         choco install wget --no-progress
         wget https://github.com/openslide/openslide-winbuild/releases/download/v20221217/openslide-win64-20221217.zip
         7z x openslide-win64-20221217.zip -oD:\openslide\
-        mklink /D D:\openslide-win64\ D:\openslide\openslide-win64-20221217\
-        cd D:\openslide-win64\
+        mklink /D C:\openslide-win64\ D:\openslide\openslide-win64-20221217\
+        cd C:\openslide-win64\
         dir
         set openslide_path=%cd%
         echo %openslide_path%

--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ Python package for:
 
       pip install -e '.[full]'
 
+## Windows Installation
+
+After installing `Openslide` you should make sure that you create a link between your installation path and
+the following default path `C:\openslide-win64\ `.
+
+```cmd
+mklink /D C:\openslide-win64\ [your-installation-path]\openslide-win64-20221217\
+```
+
+You can install the latest versions of `Openslide` for windows using the pre-built packages
+found in the project's github page:
+`https://github.com/openslide/openslide-bin/releases`
+
+or in their website:
+`https://openslide.org/download/`
+
 
 ## Examples
 How to convert imaging data from standard biomedical formats to group of TileDB arrays.

--- a/tiledb/bioimg/converters/__init__.py
+++ b/tiledb/bioimg/converters/__init__.py
@@ -2,4 +2,4 @@ FMT_VERSION = 2
 DATASET_TYPE = "bioimg"
 DEFAULT_SCRATCH_SPACE = "/dev/shm"
 # Windows use only
-WIN_OPENSLIDE_PATH = r"D:\openslide-win64\bin"
+WIN_OPENSLIDE_PATH = r"C:\openslide-win64\bin"


### PR DESCRIPTION
This PR:

- Changes the installation path of `openslide` for Windows from `D:/` to `C:`