### PR TITLE
Convert ABC base classes to Protocols

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,20 @@ setuptools.setup(
         "cloud": cloud,
         "full": full,
     },
+    entry_points={
+        "bioimg.readers": [
+            "tiff_reader = tiledb.bioimg.converters.ome_tiff:OMETiffReader",
+            "zarr_reader = tiledb.bioimg.converters.ome_zarr:OMEZarrReader",
+            "osd_reader = tiledb.bioimg.converters.openslide:OpenSlideReader",
+        ],
+        "bioimg.writers": [
+            "tiff_writer = tiledb.bioimg.converters.ome_tiff:OMETiffWriter",
+            "zarr_writer = tiledb.bioimg.converters.ome_tiff:OMEZarrWriter",
+        ],
+        "bioimg.converters": [
+            "tiff_converter = tiledb.bioimg.converters.ome_tiff:OMETiffConverter",
+            "zarr_converter = tiledb.bioimg.converters.ome_zarr:OMEZarrConverter",
+            "osd_converter = tiledb.bioimg.converters.openslide:OpenSlideConverter",
+        ],
+    },
 )

--- a/tests/integration/converters/__init__.py
+++ b/tests/integration/converters/__init__.py
@@ -1,0 +1,6 @@
+import os
+from tiledb.bioimg import WIN_OPENSLIDE_PATH
+
+if hasattr(os, "add_dll_directory"):
+    # Python >= 3.8 on Windows
+    os.add_dll_directory(WIN_OPENSLIDE_PATH)

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -8,8 +8,7 @@ import zarr
 import tiledb
 from tests import assert_image_similarity, get_path, get_schema
 from tiledb.bioimg.converters import DATASET_TYPE, FMT_VERSION
-from tiledb.bioimg.converters.ome_tiff import OMETiffReader
-from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter, OMEZarrReader
+from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter
 from tiledb.bioimg.helpers import iter_color, open_bioimg
 from tiledb.bioimg.openslide import TileDBOpenSlide
 from tiledb.cc import WebpInputFormat
@@ -25,11 +24,11 @@ def test_ome_zarr_converter_source_reader_exception(
     tiff_path = get_path("CMU-1-Small-Region.ome.tiff")
     output_reader = tmp_path / "to_tiledb_reader"
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(FileExistsError) as excinfo:
         OMEZarrConverter.to_tiledb(
-            OMETiffReader(tiff_path), str(output_reader), preserve_axes=preserve_axes
+            tiff_path, str(output_reader), preserve_axes=preserve_axes
         )
-    assert "reader should match converter" in str(excinfo)
+    assert "FileExistsError" in str(excinfo)
 
 
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
@@ -46,7 +45,7 @@ def test_ome_zarr_converter_reader_source_consistent_output(
         input_path, str(output_path), preserve_axes=preserve_axes
     )
     OMEZarrConverter.to_tiledb(
-        OMEZarrReader(input_path), str(output_reader), preserve_axes=preserve_axes
+        input_path, str(output_reader), preserve_axes=preserve_axes
     )
 
     # check the first (highest) resolution layer only
@@ -62,7 +61,7 @@ def test_ome_zarr_converter_reader_source_consistent_output(
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
 @pytest.mark.parametrize("preserve_axes", [False, True])
 def test_ome_zarr_converter(tmp_path, series_idx, preserve_axes):
-    input_path = get_path("CMU-1-Small-Region.ome.zarr") / str(series_idx)
+    input_path = get_path("CMU-1-Small-Region.ome" ".zarr") / str(series_idx)
     OMEZarrConverter.to_tiledb(input_path, str(tmp_path), preserve_axes=preserve_axes)
 
     # check the first (highest) resolution layer only

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -61,7 +61,7 @@ def test_ome_zarr_converter_reader_source_consistent_output(
 @pytest.mark.parametrize("series_idx", [0, 1, 2])
 @pytest.mark.parametrize("preserve_axes", [False, True])
 def test_ome_zarr_converter(tmp_path, series_idx, preserve_axes):
-    input_path = get_path("CMU-1-Small-Region.ome" ".zarr") / str(series_idx)
+    input_path = get_path("CMU-1-Small-Region.ome.zarr") / str(series_idx)
     OMEZarrConverter.to_tiledb(input_path, str(tmp_path), preserve_axes=preserve_axes)
 
     # check the first (highest) resolution layer only

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -1,7 +1,6 @@
 import json
 
 import numpy as np
-import openslide
 import PIL.Image
 import pytest
 
@@ -40,6 +39,8 @@ def test_openslide_converter(tmp_path, preserve_axes, chunked, max_workers, comp
     with open_bioimg(str(tmp_path / "l_0.tdb")) as A:
         if not preserve_axes:
             assert A.schema == get_schema(2220, 2967, 4, compressor=compressor)
+
+    import openslide
 
     o = openslide.open_slide(input_path)
     with TileDBOpenSlide(output_path) as t:

--- a/tiledb/bioimg/__init__.py
+++ b/tiledb/bioimg/__init__.py
@@ -2,6 +2,39 @@ ATTR_NAME = "intensity"
 WHITE_RGB = 16777215  # FFFFFF in hex
 WHITE_RGBA = 4294967295  # FFFFFFFF in hex
 EXPORT_TILE_SIZE = 256
+WIN_OPENSLIDE_PATH = r"C:\openslide-win64\bin"
 
+import importlib.util
+import os
+import warnings
+from typing import Optional
 from .types import Converters
-from .wrappers import from_bioimg, to_bioimg
+
+osd_exc: Optional[ImportError]
+
+if hasattr(os, "add_dll_directory"):
+    # Python >= 3.8 on Windows
+    with os.add_dll_directory(WIN_OPENSLIDE_PATH):
+        try:
+            importlib.util.find_spec("openslide")
+        except ImportError as err_osd:
+            warnings.warn(
+                "Openslide Converter requires 'openslide-python' package. "
+                "You can install 'tiledb-bioimg' with the 'openslide' or 'full' flag"
+            )
+            osd_exc = err_osd
+        else:
+            osd_exc = None
+else:
+    try:
+        importlib.util.find_spec("openslide")
+    except ImportError as err_osd:
+        warnings.warn(
+            "Openslide Converter requires 'openslide-python' package. "
+            "You can install 'tiledb-bioimg' with the 'openslide' or 'full' flag"
+        )
+        osd_exc = err_osd
+    else:
+        osd_exc = None
+
+from .wrappers import *

--- a/tiledb/bioimg/converters/__init__.py
+++ b/tiledb/bioimg/converters/__init__.py
@@ -1,5 +1,3 @@
 FMT_VERSION = 2
 DATASET_TYPE = "bioimg"
 DEFAULT_SCRATCH_SPACE = "/dev/shm"
-# Windows use only
-WIN_OPENSLIDE_PATH = r"C:\openslide-win64\bin"

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -58,7 +58,7 @@ from .axes import Axes
 from .tiles import iter_tiles, num_tiles
 
 
-class ImageReader(ABC):
+class ImageReader(Protocol):
     @abstractmethod
     def __init__(
         self,
@@ -175,7 +175,7 @@ class ImageReader(ABC):
         """
 
 
-class ImageWriter(ABC):
+class ImageWriter(Protocol):
     @abstractmethod
     def __init__(self, output_path: str, logger: logging.Logger, **kwargs: Any):
         """Initialize this ImageWriter"""

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -5,19 +5,21 @@ import logging
 import os
 import threading
 import warnings
-from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
 from operator import itemgetter
 from typing import (
     Any,
     Dict,
+    Generic,
     Iterator,
     Mapping,
     MutableMapping,
     Optional,
+    Protocol,
     Sequence,
     Tuple,
     Type,
+    TypeVar,
     Union,
 )
 
@@ -59,55 +61,40 @@ from .tiles import iter_tiles, num_tiles
 
 
 class ImageReader(Protocol):
-    @abstractmethod
-    def __init__(
-        self,
-        input_path: str,
-        *,
-        logger: Optional[logging.Logger],
-        source_config: Optional[tiledb.Config] = None,
-        source_ctx: Optional[tiledb.Ctx] = None,
-        dest_config: Optional[tiledb.Config] = None,
-        dest_ctx: Optional[tiledb.Config] = None,
-        **kwargs: Any,
-    ):
-        """Initialize this ImageReader"""
 
-    def __enter__(self) -> ImageReader:
-        return self
+    def __enter__(self) -> ImageReader: ...
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        pass
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None: ...
 
     @property
-    @abstractmethod
     def source_ctx(self) -> tiledb.Ctx:
         """The ctx of the source path of this image reader."""
+        ...
 
     @property
-    @abstractmethod
     def dest_ctx(self) -> tiledb.Ctx:
         """The ctx of the dest path of this image reader."""
+        ...
 
     @property
-    @abstractmethod
     def logger(self) -> Optional[logging.Logger]:
         """The logger of this image reader."""
+        ...
 
     @logger.setter
-    @abstractmethod
     def logger(self, default_logger: logging.Logger) -> None:
         """The setter for the logger of this image reader"""
+        ...
 
     @property
-    @abstractmethod
     def axes(self) -> Axes:
         """The axes of this multi-resolution image."""
+        ...
 
     @property
-    @abstractmethod
     def channels(self) -> Sequence[str]:
         """Names of the channels (C axis) of this multi-resolution image."""
+        ...
 
     @property
     def webp_format(self) -> WebpInputFormat:
@@ -115,23 +102,22 @@ class ImageReader(Protocol):
         return WebpInputFormat.WEBP_NONE
 
     @property
-    @abstractmethod
     def level_count(self) -> int:
         """
         The number of levels for this multi-resolution image.
 
         Levels are numbered from 0 (highest resolution) to level_count - 1 (lowest resolution).
         """
+        ...
 
-    @abstractmethod
     def level_dtype(self, level: int) -> np.dtype:
         """Return the dtype of the image for the given level."""
+        ...
 
-    @abstractmethod
     def level_shape(self, level: int) -> Tuple[int, ...]:
         """Return the shape of the image for the given level."""
+        ...
 
-    @abstractmethod
     def level_image(
         self, level: int, tile: Optional[Tuple[slice, ...]] = None
     ) -> np.ndarray:
@@ -143,27 +129,27 @@ class ImageReader(Protocol):
         :param tile: If not None, a tuple of slices (one per each axes) that specify the
             subregion of the image to return.
         """
+        ...
 
-    @abstractmethod
     def level_metadata(self, level: int) -> Dict[str, Any]:
         """Return the metadata for the given level."""
+        ...
 
     @property
-    @abstractmethod
     def group_metadata(self) -> Dict[str, Any]:
         """Return the metadata for the whole multi-resolution image."""
+        ...
 
     @property
-    @abstractmethod
     def image_metadata(self) -> Dict[str, Any]:
         """Return the metadata for the whole multi-resolution image."""
+        ...
 
     @property
-    @abstractmethod
     def original_metadata(self) -> Dict[str, Any]:
         """Return the metadata of the original file."""
+        ...
 
-    @abstractmethod
     def optimal_reader(
         self, level: int, max_workers: int = 0
     ) -> Union[None, Iterator[Tuple[Tuple[slice, ...], NDArray[Any]]]]:
@@ -173,25 +159,19 @@ class ImageReader(Protocol):
         :param level: The overview to read from
         :param max_workers: The number of thread to spawn to read from the file
         """
+        ...
 
 
 class ImageWriter(Protocol):
-    @abstractmethod
-    def __init__(self, output_path: str, logger: logging.Logger, **kwargs: Any):
-        """Initialize this ImageWriter"""
-        self.logger = logger
 
-    def __enter__(self) -> ImageWriter:
-        return self
+    def __enter__(self) -> ImageWriter: ...
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        pass
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None: ...
 
-    @abstractmethod
     def write_group_metadata(self, metadata: Mapping[str, Any]) -> None:
         """Write metadata for the whole multi-resolution image."""
+        ...
 
-    @abstractmethod
     def compute_level_metadata(
         self,
         baseline: bool,
@@ -208,8 +188,8 @@ class ImageWriter(Protocol):
         :param group_metadata: The TileDB group pyramid metadata
         :param array_metadata: The TileDB array level metadata
         """
+        ...
 
-    @abstractmethod
     def write_level_image(
         self,
         image: np.ndarray,
@@ -224,13 +204,28 @@ class ImageWriter(Protocol):
         :param metadata: Metadata for the given level
         :param image_mask: Mask the original image depending on export format requirements
         """
+        ...
 
 
-class ImageConverter:
+# Define covariant type variables
+TReader = TypeVar("TReader", bound=ImageReader)
+TWriter = TypeVar("TWriter", bound=ImageWriter)
+
+
+class ImageConverter(Protocol[TReader, TWriter]):
+    _ImageReaderType: Optional[Type[TReader]] = None
+    _ImageWriterType: Optional[Type[TWriter]] = None
+
+    def from_tiledb(self) -> ImageConverter[TReader, TWriter]: ...
+
+    def to_tiledb(self) -> ImageConverter[TReader, TWriter]: ...
+
+
+class ImageConverterMixin(Generic[TReader, TWriter]):
     # setting a tile to "infinite" effectively makes it equal to the dimension size
     _DEFAULT_TILES = {"T": 1, "C": np.inf, "Z": 1, "Y": 1024, "X": 1024}
-    _ImageReaderType: Optional[Type[ImageReader]] = None
-    _ImageWriterType: Optional[Type[ImageWriter]] = None
+    _ImageReaderType: Optional[Type[TReader]] = None
+    _ImageWriterType: Optional[Type[TWriter]] = None
 
     @classmethod
     def from_tiledb(
@@ -245,14 +240,14 @@ class ImageConverter:
         scratch_space: str = DEFAULT_SCRATCH_SPACE,
         log: Optional[Union[bool, logging.Logger]] = None,
         **writer_kwargs: Mapping[str, Any],
-    ) -> Type[ImageConverter]:
+    ) -> Type[ImageConverterMixin[Any, Any]]:
         """
         Convert a TileDB Group of Arrays back to other format images, one per level
         :param input_path: path to the TileDB group of arrays
         :param output_path: path to the image
         :param level_min: minimum level of the image to be converted. By default set to 0
             to convert all levels
-        :param attr: attribute name for backwards compatiblity support
+        :param attr: attribute name for backwards compatibility support
         :param config: tiledb configuration either a dict or a tiledb.Config of source
         :param output_config: tiledb configuration either a dict or a tiledb.Config of destination
         :param scratch_space: shared memory or cache space for cloud random access export support
@@ -261,15 +256,15 @@ class ImageConverter:
         DEBUG logging level.
         """
 
+        if cls._ImageWriterType is None:
+            raise NotImplementedError(f"{cls} does not support exporting")
+
         # Initializes the logger depending on the API path chosen
         if log:
             logger = get_logger_wrapper(log) if isinstance(log, bool) else log
         else:
             default_verbose = False
             logger = get_logger_wrapper(default_verbose)
-
-        if cls._ImageWriterType is None:
-            raise NotImplementedError(f"{cls} does not support exporting")
 
         out_uri_res, scheme = resolve_path(output_path)
         logger.debug(f"Resolving output path {out_uri_res}, with scheme {scheme}")
@@ -288,7 +283,9 @@ class ImageConverter:
             output_config = config
 
         slide = TileDBOpenSlide(input_path, attr=attr, config=config)
-        writer = cls._ImageWriterType(destination_uri, logger)
+        writer = cls._ImageWriterType(
+            destination_uri, logger, **writer_kwargs if writer_kwargs else {}
+        )
 
         with slide, writer:
             writer.write_group_metadata(slide.properties)
@@ -321,7 +318,7 @@ class ImageConverter:
     @classmethod
     def to_tiledb(
         cls,
-        source: Union[str, ImageReader],
+        source: str,
         output_path: str,
         *,
         level_min: int = 0,
@@ -337,7 +334,7 @@ class ImageConverter:
         log: Optional[Union[bool, logging.Logger]] = None,
         reader_kwargs: Optional[MutableMapping[str, Any]] = None,
         pyramid_kwargs: Optional[Mapping[str, Any]] = None,
-    ) -> Type[ImageConverter]:
+    ) -> Type[ImageConverterMixin[Any, Any]]:
         """
                 Convert an image to a TileDB Group of Arrays, one per level.
 
@@ -384,6 +381,9 @@ class ImageConverter:
                         on the machine, multiplied by 5.
         """
 
+        if cls._ImageReaderType is None:
+            raise NotImplementedError(f"{cls} does not support importing")
+
         if log:
             logger = get_logger_wrapper(log) if isinstance(log, bool) else log
         else:
@@ -399,18 +399,9 @@ class ImageConverter:
                     common_cfg
                 )
 
-        if isinstance(source, ImageReader):
-            if cls._ImageReaderType != source.__class__:
-                raise ValueError("Image reader should match converter on source format")
-            if not source.logger:
-                source.logger = logger
-            reader = source
-        elif cls._ImageReaderType is not None:
-            reader = cls._ImageReaderType(
-                source, logger=logger, **reader_kwargs if reader_kwargs else {}
-            )
-        else:
-            raise NotImplementedError(f"{cls} does not support importing")
+        reader = cls._ImageReaderType(
+            source, logger, **reader_kwargs if reader_kwargs else {}
+        )
 
         max_tiles = cls._DEFAULT_TILES.copy()
         logger.debug(f"Max tiles:{max_tiles}")
@@ -419,7 +410,6 @@ class ImageConverter:
         logger.debug(f"Updated max tiles:{max_tiles}")
 
         rw_group = ReadWriteGroup(output_path, ctx=reader.dest_ctx)
-
         metadata = {}
         original_metadata = {}
 
@@ -488,7 +478,7 @@ class ImageConverter:
                         f"The image contains multiple levels but only level {level_min} "
                         "will be considered for generating the image pyramid"
                     )
-                level_meta = _convert_level_to_tiledb(level_min, **convert_kwargs)  # type: ignore
+                level_meta = _convert_level_to_tiledb(level_min, **convert_kwargs)
 
                 scaled_compressors, levels_meta = _create_image_pyramid(
                     reader,
@@ -506,7 +496,7 @@ class ImageConverter:
             else:
                 for level in range(level_min, reader.level_count):
                     logger.info(f"Converting level: {level}")
-                    level_meta = _convert_level_to_tiledb(level, **convert_kwargs)  # type: ignore
+                    level_meta = _convert_level_to_tiledb(level, **convert_kwargs)
                     channel_min_max.append(level_meta["channelMinMax"])
                     logger.debug(
                         f'Level {level} channel MinMax: {level_meta["channelMinMax"]}'

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -240,7 +240,7 @@ class ImageConverterMixin(Generic[TReader, TWriter]):
         scratch_space: str = DEFAULT_SCRATCH_SPACE,
         log: Optional[Union[bool, logging.Logger]] = None,
         **writer_kwargs: Mapping[str, Any],
-    ) -> Type[ImageConverterMixin[Any, Any]]:
+    ) -> Type[ImageConverterMixin[TReader, TWriter]]:
         """
         Convert a TileDB Group of Arrays back to other format images, one per level
         :param input_path: path to the TileDB group of arrays
@@ -334,7 +334,7 @@ class ImageConverterMixin(Generic[TReader, TWriter]):
         log: Optional[Union[bool, logging.Logger]] = None,
         reader_kwargs: Optional[MutableMapping[str, Any]] = None,
         pyramid_kwargs: Optional[Mapping[str, Any]] = None,
-    ) -> Type[ImageConverterMixin[Any, Any]]:
+    ) -> Type[ImageConverterMixin[TReader, TWriter]]:
         """
                 Convert an image to a TileDB Group of Arrays, one per level.
 

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -27,6 +27,7 @@ import jsonpickle
 import numpy as np
 from numpy._typing import NDArray
 from tqdm import tqdm
+from typing_extensions import Self
 
 from .scale import Scaler
 
@@ -65,8 +66,9 @@ TWriter = TypeVar("TWriter", bound="ImageWriter")
 
 
 class ImageReader(Protocol):
+    _logger: logging.Logger
 
-    def __enter__(self: TReader) -> TReader: ...
+    def __enter__(self) -> Self: ...
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None: ...
 
@@ -83,11 +85,6 @@ class ImageReader(Protocol):
     @property
     def logger(self) -> Optional[logging.Logger]:
         """The logger of this image reader."""
-        ...
-
-    @logger.setter
-    def logger(self, default_logger: logging.Logger) -> None:
-        """The setter for the logger of this image reader"""
         ...
 
     @property
@@ -168,7 +165,7 @@ class ImageReader(Protocol):
 
 class ImageWriter(Protocol):
 
-    def __enter__(self: TWriter) -> TWriter: ...
+    def __enter__(self) -> Self: ...
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None: ...
 
@@ -216,10 +213,10 @@ class ImageConverter(Protocol[TReader, TWriter]):
     _ImageWriterType: Optional[Type[TWriter]] = None
 
     @classmethod
-    def from_tiledb(cls) -> ImageConverter[TReader, TWriter]: ...
+    def from_tiledb(cls, input_path: str, output_path: str) -> Type[Self]: ...
 
     @classmethod
-    def to_tiledb(cls) -> ImageConverter[TReader, TWriter]: ...
+    def to_tiledb(cls, source: str, output_path: str) -> Type[Self]: ...
 
 
 class ImageConverterMixin(Generic[TReader, TWriter]):

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import decimal
 import logging
 import math
@@ -34,17 +36,17 @@ from tiledb.highlevel import _get_ctx
 from .. import ATTR_NAME, EXPORT_TILE_SIZE, WHITE_RGBA
 from ..helpers import get_decimal_from_rgba, get_logger_wrapper, get_rgba, iter_color
 from .axes import Axes
-from .base import ImageConverter, ImageReader, ImageWriter
+from .base import ImageConverterMixin
 from .io import as_array
 from .metadata import qpi_image_meta, qpi_original_meta
 
 
-class OMETiffReader(ImageReader):
+class OMETiffReader:
     def __init__(
         self,
         input_path: str,
-        *,
         logger: Optional[logging.Logger] = None,
+        *,
         source_config: Optional[Config] = None,
         source_ctx: Optional[Ctx] = None,
         dest_config: Optional[Config] = None,
@@ -75,6 +77,9 @@ class OMETiffReader(ImageReader):
         self._series = self._tiff.series[0]
         omexml = self._tiff.ome_metadata
         self._metadata = tifffile.xml2dict(omexml) if omexml else {}
+
+    def __enter__(self) -> OMETiffReader:
+        return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self._tiff.close()
@@ -395,11 +400,17 @@ class OMETiffReader(ImageReader):
         return chunk_iterator()
 
 
-class OMETiffWriter(ImageWriter):
+class OMETiffWriter:
     def __init__(self, output_path: str, logger: logging.Logger, ome: bool = True):
         self._logger = logger
         self._output_path = output_path
         self._ome = ome
+
+    def __enter__(self) -> OMETiffWriter:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self._writer.close()
 
     def write_group_metadata(self, metadata: Mapping[str, Any]) -> None:
         self._writer = tifffile.TiffWriter(
@@ -499,11 +510,8 @@ class OMETiffWriter(ImageWriter):
         write_kwargs: Dict[str, Any] = dict(metadata)
         self._writer.write(image, **write_kwargs)
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self._writer.close()
 
-
-class OMETiffConverter(ImageConverter):
+class OMETiffConverter(ImageConverterMixin[OMETiffReader, OMETiffWriter]):
     """Converter of Tiff-supported images to TileDB Groups of Arrays"""
 
     _ImageReaderType = OMETiffReader

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -42,6 +42,9 @@ from .metadata import qpi_image_meta, qpi_original_meta
 
 
 class OMETiffReader:
+
+    _logger: logging.Logger
+
     def __init__(
         self,
         input_path: str,
@@ -96,10 +99,6 @@ class OMETiffReader:
     @property
     def logger(self) -> Optional[logging.Logger]:
         return self._logger
-
-    @logger.setter
-    def logger(self, default_logger: logging.Logger) -> None:
-        self._logger = default_logger
 
     @property
     def axes(self) -> Axes:

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -42,6 +42,9 @@ from .base import ImageConverterMixin
 
 
 class OMEZarrReader:
+
+    _logger: logging.Logger
+
     def __init__(
         self,
         input_path: str,
@@ -86,10 +89,6 @@ class OMEZarrReader:
     @property
     def logger(self) -> Optional[logging.Logger]:
         return self._logger
-
-    @logger.setter
-    def logger(self, default_logger: logging.Logger) -> None:
-        self._logger = default_logger
 
     @property
     def axes(self) -> Axes:

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -38,15 +38,15 @@ from tiledb.highlevel import _get_ctx
 from .. import WHITE_RGB
 from ..helpers import get_logger_wrapper, get_rgba, translate_config_to_s3fs
 from .axes import Axes
-from .base import ImageConverter, ImageReader, ImageWriter
+from .base import ImageConverterMixin
 
 
-class OMEZarrReader(ImageReader):
+class OMEZarrReader:
     def __init__(
         self,
         input_path: str,
-        *,
         logger: Optional[logging.Logger] = None,
+        *,
         source_config: Optional[Config] = None,
         source_ctx: Optional[Ctx] = None,
         dest_config: Optional[Config] = None,
@@ -68,6 +68,12 @@ class OMEZarrReader(ImageReader):
         self._root_node = next(Reader(ZarrLocation(input_fh))())
         self._multiscales = cast(Multiscales, self._root_node.load(Multiscales))
         self._omero = cast(Optional[OMERO], self._root_node.load(OMERO))
+
+    def __enter__(self) -> OMEZarrReader:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        pass
 
     @property
     def source_ctx(self) -> Ctx:
@@ -210,7 +216,7 @@ class OMEZarrReader(ImageReader):
         return None
 
 
-class OMEZarrWriter(ImageWriter):
+class OMEZarrWriter:
     def __init__(self, output_path: str, logger: logging.Logger):
         """
         OME-Zarr image writer from TileDB
@@ -224,6 +230,9 @@ class OMEZarrWriter(ImageWriter):
         self._pyramid: List[np.ndarray] = []
         self._storage_options: List[Dict[str, Any]] = []
         self._group_metadata: Dict[str, Any] = {}
+
+    def __enter__(self) -> OMEZarrWriter:
+        return self
 
     def write_group_metadata(self, metadata: Mapping[str, Any]) -> None:
         self._group_metadata = json.loads(metadata["json_zarrwriter_kwargs"])
@@ -268,7 +277,7 @@ class OMEZarrWriter(ImageWriter):
             self._group.attrs["omero"] = group_metadata["omero"]
 
 
-class OMEZarrConverter(ImageConverter):
+class OMEZarrConverter(ImageConverterMixin[OMEZarrReader, OMEZarrWriter]):
     """Converter of Zarr-supported images to TileDB Groups of Arrays"""
 
     _ImageReaderType = OMEZarrReader

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import warnings
@@ -35,15 +37,15 @@ from tiledb.highlevel import _get_ctx
 from ..helpers import cache_filepath, get_logger_wrapper, is_remote_protocol, iter_color
 from . import DEFAULT_SCRATCH_SPACE
 from .axes import Axes
-from .base import ImageConverter, ImageReader
+from .base import ImageConverterMixin
 
 
-class OpenSlideReader(ImageReader):
+class OpenSlideReader:
     def __init__(
         self,
         input_path: str,
-        *,
         logger: Optional[logging.Logger] = None,
+        *,
         source_config: Optional[Config] = None,
         source_ctx: Optional[Ctx] = None,
         dest_config: Optional[Config] = None,
@@ -67,6 +69,9 @@ class OpenSlideReader(ImageReader):
         else:
             resolved_path = input_path
         self._osd = osd.OpenSlide(resolved_path)
+
+    def __enter__(self) -> OpenSlideReader:
+        return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self._osd.close()
@@ -181,7 +186,7 @@ class OpenSlideReader(ImageReader):
         return None
 
 
-class OpenSlideConverter(ImageConverter):
+class OpenSlideConverter(ImageConverterMixin[OpenSlideReader, Any]):
     """Converter of OpenSlide-supported images to TileDB Groups of Arrays"""
 
     _ImageReaderType = OpenSlideReader

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -41,6 +41,9 @@ from .base import ImageConverterMixin
 
 
 class OpenSlideReader:
+
+    _logger: logging.Logger
+
     def __init__(
         self,
         input_path: str,
@@ -87,10 +90,6 @@ class OpenSlideReader:
     @property
     def logger(self) -> Optional[logging.Logger]:
         return self._logger
-
-    @logger.setter
-    def logger(self, default_logger: logging.Logger) -> None:
-        self._logger = default_logger
 
     @property
     def axes(self) -> Axes:

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -1,35 +1,12 @@
 from __future__ import annotations
 
 import logging
-import os
-import warnings
 from typing import Any, Dict, Iterator, Optional, Sequence, Tuple, cast
 
 import numpy as np
+import openslide as osd
 from numpy._typing import NDArray
 
-from . import WIN_OPENSLIDE_PATH
-
-if hasattr(os, "add_dll_directory"):
-    # Python >= 3.8 on Windows
-    with os.add_dll_directory(WIN_OPENSLIDE_PATH):
-        try:
-            import openslide as osd
-        except ImportError as err:
-            warnings.warn(
-                "Openslide Converter requires 'openslide-python' package. "
-                "You can install 'tiledb-bioimg' with the 'openslide' or 'full' flag"
-            )
-            raise err
-else:
-    try:
-        import openslide as osd
-    except ImportError as err:
-        warnings.warn(
-            "Openslide Converter requires 'openslide-python' package. "
-            "You can install 'tiledb-bioimg' with the 'openslide' or 'full' flag"
-        )
-        raise err
 from tiledb import Config, Ctx
 from tiledb.cc import WebpInputFormat
 from tiledb.highlevel import _get_ctx

--- a/tiledb/bioimg/plugin_manager.py
+++ b/tiledb/bioimg/plugin_manager.py
@@ -1,0 +1,28 @@
+import importlib.metadata
+from typing import Any, Mapping, Type
+
+from tiledb.bioimg.converters import ImageConverterMixin, ImageReader, ImageWriter
+
+
+class PluginManager:
+
+    @staticmethod
+    def load_readers() -> Mapping[str, ImageReader]:
+        readers = {}
+        for entry_point in importlib.metadata.entry_points()["bioimg.readers"]:
+            readers[entry_point.name] = entry_point.load()
+        return readers
+
+    @staticmethod
+    def load_writers() -> Mapping[str, ImageWriter]:
+        writers = {}
+        for entry_point in importlib.metadata.entry_points()["bioimg.writers"]:
+            writers[entry_point.name] = entry_point.load()
+        return writers
+
+    @staticmethod
+    def load_converters() -> Mapping[str, Type[ImageConverterMixin[Any, Any]]]:
+        converters = {}
+        for entry_point in importlib.metadata.entry_points()["bioimg.converters"]:
+            converters[entry_point.name] = entry_point.load()
+        return converters

--- a/tiledb/bioimg/plugin_manager.py
+++ b/tiledb/bioimg/plugin_manager.py
@@ -1,28 +1,21 @@
 import importlib.metadata
 from typing import Any, Mapping, Type
 
-from tiledb.bioimg.converters import ImageConverterMixin, ImageReader, ImageWriter
+from .converters.base import ImageConverterMixin, ImageReader, ImageWriter
 
 
-class PluginManager:
+def _load_entrypoints(name: str) -> Mapping[str, Any]:
+    eps = importlib.metadata.entry_points()[name]
+    return {ep.name: ep.load() for ep in eps}
 
-    @staticmethod
-    def load_readers() -> Mapping[str, ImageReader]:
-        readers = {}
-        for entry_point in importlib.metadata.entry_points()["bioimg.readers"]:
-            readers[entry_point.name] = entry_point.load()
-        return readers
 
-    @staticmethod
-    def load_writers() -> Mapping[str, ImageWriter]:
-        writers = {}
-        for entry_point in importlib.metadata.entry_points()["bioimg.writers"]:
-            writers[entry_point.name] = entry_point.load()
-        return writers
+def load_readers() -> Mapping[str, ImageReader]:
+    return _load_entrypoints("bioimg.readers")
 
-    @staticmethod
-    def load_converters() -> Mapping[str, Type[ImageConverterMixin[Any, Any]]]:
-        converters = {}
-        for entry_point in importlib.metadata.entry_points()["bioimg.converters"]:
-            converters[entry_point.name] = entry_point.load()
-        return converters
+
+def load_writers() -> Mapping[str, ImageWriter]:
+    return _load_entrypoints("bioimg.writers")
+
+
+def load_converters() -> Mapping[str, Type[ImageConverterMixin[Any, Any]]]:
+    return _load_entrypoints("bioimg.converters")

--- a/tiledb/bioimg/wrappers.py
+++ b/tiledb/bioimg/wrappers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Type
 
-from .converters.base import ImageConverter
+from .converters.base import ImageConverterMixin
 
 try:
     from .converters.ome_tiff import OMETiffConverter
@@ -36,7 +36,7 @@ def from_bioimg(
     exclude_metadata: bool = False,
     tile_scale: int = 1,
     **kwargs: Any,
-) -> Type[ImageConverter]:
+) -> Type[ImageConverterMixin[Any, Any]]:
     """
     This function is a wrapper and serves as an all-inclusive API for encapsulating the
     ingestion of different file formats
@@ -110,7 +110,7 @@ def to_bioimg(
     *,
     verbose: bool = False,
     **kwargs: Any,
-) -> Type[ImageConverter]:
+) -> Type[ImageConverterMixin[Any, Any]]:
     """
     This function is a wrapper and serves as an all-inclusive API for encapsulating the
     exportation of TileDB ingested bio-images back into different file formats

--- a/tiledb/bioimg/wrappers.py
+++ b/tiledb/bioimg/wrappers.py
@@ -4,26 +4,29 @@ from importlib import util
 from typing import Any
 
 try:
-    util.find_spec(".converters.ome_tiff.OMETiffConverter")
+    util.find_spec("tifffile")
+    util.find_spec("imagecodecs")
 except ImportError as err_tiff:
     _tiff_exc = err_tiff
 else:
     _tiff_exc = None  # type: ignore
 try:
-    util.find_spec(".converters.ome_zarr.OMEZarrConverter")
+    util.find_spec("zarr")
+    util.find_spec("ome-zarr")
 except ImportError as err_zarr:
     _zarr_exc = err_zarr
 else:
     _zarr_exc = None  # type: ignore
 try:
-    util.find_spec(".converters.openslide.OpenSlideConverter")
+    util.find_spec("openslide")
+    util.find_spec("openslide-python")
 except ImportError as err_osd:
     _osd_exc = err_osd
 else:
     _osd_exc = None  # type: ignore
 
 from .helpers import get_logger_wrapper
-from .plugin_manager import PluginManager
+from .plugin_manager import load_converters
 from .types import Converters
 
 
@@ -65,9 +68,7 @@ def from_bioimg(
     reader_kwargs["dest_config"] = kwargs.pop(
         "dest_config", reader_kwargs["source_config"]
     )
-    pm = PluginManager()
-    converters = pm.load_converters()
-
+    converters = load_converters()
     if converter is Converters.OMETIFF:
         if not _tiff_exc:
             logger.info("Converting OME-TIFF file")
@@ -131,8 +132,7 @@ def to_bioimg(
     :return: None
     """
 
-    pm = PluginManager()
-    converters = pm.load_converters()
+    converters = load_converters()
     logger = get_logger_wrapper(verbose)
     if converter is Converters.OMETIFF:
         if not _tiff_exc:

--- a/tiledb/bioimg/wrappers.py
+++ b/tiledb/bioimg/wrappers.py
@@ -1,29 +1,28 @@
 from __future__ import annotations
 
-from importlib import util
-from typing import Any
+import importlib.util
+from typing import Any, Optional
 
 try:
-    util.find_spec("tifffile")
-    util.find_spec("imagecodecs")
+    importlib.util.find_spec("tifffile")
+    importlib.util.find_spec("imagecodecs")
 except ImportError as err_tiff:
-    _tiff_exc = err_tiff
+    _tiff_exc: Optional[ImportError] = err_tiff
 else:
-    _tiff_exc = None  # type: ignore
+    _tiff_exc = None
 try:
-    util.find_spec("zarr")
-    util.find_spec("ome-zarr")
+    importlib.util.find_spec("zarr")
+    importlib.util.find_spec("ome-zarr")
 except ImportError as err_zarr:
-    _zarr_exc = err_zarr
+    _zarr_exc: Optional[ImportError] = err_zarr
 else:
-    _zarr_exc = None  # type: ignore
+    _zarr_exc = None
 try:
-    util.find_spec("openslide")
-    util.find_spec("openslide-python")
+    importlib.util.find_spec("openslide-python")
 except ImportError as err_osd:
-    _osd_exc = err_osd
+    _osd_exc: Optional[ImportError] = err_osd
 else:
-    _osd_exc = None  # type: ignore
+    _osd_exc = None
 
 from .helpers import get_logger_wrapper
 from .plugin_manager import load_converters

--- a/tiledb/bioimg/wrappers.py
+++ b/tiledb/bioimg/wrappers.py
@@ -17,13 +17,9 @@ except ImportError as err_zarr:
     _zarr_exc: Optional[ImportError] = err_zarr
 else:
     _zarr_exc = None
-try:
-    importlib.util.find_spec("openslide-python")
-except ImportError as err_osd:
-    _osd_exc: Optional[ImportError] = err_osd
-else:
-    _osd_exc = None
 
+
+from . import osd_exc
 from .helpers import get_logger_wrapper
 from .plugin_manager import load_converters
 from .types import Converters
@@ -97,7 +93,7 @@ def from_bioimg(
         else:
             raise _zarr_exc
     else:
-        if not _osd_exc:
+        if not osd_exc:
             logger.info("Converting Openslide")
             return converters["osd_converter"].to_tiledb(
                 source=src,
@@ -109,7 +105,7 @@ def from_bioimg(
                 **kwargs,
             )
         else:
-            raise _osd_exc
+            raise osd_exc
 
 
 def to_bioimg(


### PR DESCRIPTION
This PR:

- Modifies the `ImageReader` and `ImageWriter` from using abstract base classes to use protocols. This will allow third-party plugins to define `ImageReader` and `ImageWriter` classes without importing `TileDB-BioImaging`.