### PR TITLE
Support source dest configs ingestion

### DIFF
--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -319,7 +319,7 @@ class ImageConverter:
         exclude_metadata: bool = False,
         compressor: Optional[Union[Mapping[int, Any], Any]] = None,
         log: Optional[Union[bool, logging.Logger]] = None,
-        reader_kwargs: Optional[Mapping[str, Any]] = None,
+        reader_kwargs: Optional[MutableMapping[str, Any]] = None,
         pyramid_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> Type[ImageConverter]:
         """
@@ -369,6 +369,15 @@ class ImageConverter:
         else:
             default_verbose = False
             logger = get_logger_wrapper(default_verbose)
+
+        # Backwards compatibility config v0.2.13
+        if reader_kwargs:
+            common_cfg = reader_kwargs.get("config", None)
+            if common_cfg:
+                # Overwrite the source and destination configs with the common
+                reader_kwargs["source_config"] = reader_kwargs[
+                    "dest_config"
+                ] = common_cfg
 
         if isinstance(source, ImageReader):
             if cls._ImageReaderType != source.__class__:

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -32,8 +32,10 @@ class OMETiffReader(ImageReader):
         input_path: str,
         *,
         logger: Optional[logging.Logger] = None,
-        config: Optional[Config] = None,
-        ctx: Optional[Ctx] = None,
+        source_config: Optional[Config] = None,
+        source_ctx: Optional[Ctx] = None,
+        dest_config: Optional[Config] = None,
+        dest_ctx: Optional[Ctx] = None,
         extra_tags: Sequence[Union[str, int]] = (),
     ):
         """
@@ -47,9 +49,11 @@ class OMETiffReader(ImageReader):
 
         # Use VFS for all paths local or remote for reading the input image
         self._input_path = input_path
-        self._ctx = _get_ctx(ctx, config)
-        self._cfg = self._ctx.config()
-        self._vfs = VFS(config=self._cfg, ctx=self._ctx)
+        self._source_ctx = _get_ctx(source_ctx, source_config)
+        self._source_cfg = self._source_ctx.config()
+        self._dest_ctx = _get_ctx(dest_ctx, dest_config)
+        self._dest_cfg = self._dest_ctx.config()
+        self._vfs = VFS(config=self._source_cfg, ctx=self._source_ctx)
         self._vfs_fh = self._vfs.open(input_path, mode="rb")
         self._tiff = tifffile.TiffFile(self._vfs_fh)
         # XXX ignore all but the first series
@@ -62,8 +66,12 @@ class OMETiffReader(ImageReader):
         self._vfs.close(file=self._vfs_fh)
 
     @property
-    def ctx(self) -> Ctx:
-        return self._ctx
+    def source_ctx(self) -> Ctx:
+        return self._source_ctx
+
+    @property
+    def dest_ctx(self) -> Ctx:
+        return self._dest_ctx
 
     @property
     def logger(self) -> Optional[logging.Logger]:

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -36,17 +36,21 @@ class OMEZarrReader(ImageReader):
         input_path: str,
         *,
         logger: Optional[logging.Logger] = None,
-        config: Optional[Config] = None,
-        ctx: Optional[Ctx] = None,
+        source_config: Optional[Config] = None,
+        source_ctx: Optional[Ctx] = None,
+        dest_config: Optional[Config] = None,
+        dest_ctx: Optional[Ctx] = None,
     ):
         """
         OME-Zarr image reader
         :param input_path: The path to the Zarr image
         """
         self._logger = get_logger_wrapper(False) if not logger else logger
-        self._ctx = _get_ctx(ctx, config)
-        self._cfg = self._ctx.config()
-        storage_options = translate_config_to_s3fs(self._cfg)
+        self._source_ctx = _get_ctx(source_ctx, source_config)
+        self._source_cfg = self._source_ctx.config()
+        self._dest_ctx = _get_ctx(dest_ctx, dest_config)
+        self._dest_cfg = self._dest_ctx.config()
+        storage_options = translate_config_to_s3fs(self._source_cfg)
         input_fh = zarr.storage.FSStore(
             input_path, check=True, create=True, **storage_options
         )
@@ -55,8 +59,12 @@ class OMEZarrReader(ImageReader):
         self._omero = cast(Optional[OMERO], self._root_node.load(OMERO))
 
     @property
-    def ctx(self) -> Ctx:
-        return self._ctx
+    def source_ctx(self) -> Ctx:
+        return self._source_ctx
+
+    @property
+    def dest_ctx(self) -> Ctx:
+        return self._dest_ctx
 
     @property
     def logger(self) -> Optional[logging.Logger]:

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -43,8 +43,10 @@ class OpenSlideReader(ImageReader):
         input_path: str,
         *,
         logger: Optional[logging.Logger] = None,
-        config: Optional[Config] = None,
-        ctx: Optional[Ctx] = None,
+        source_config: Optional[Config] = None,
+        source_ctx: Optional[Ctx] = None,
+        dest_config: Optional[Config] = None,
+        dest_ctx: Optional[Ctx] = None,
         scratch_space: str = DEFAULT_SCRATCH_SPACE,
     ):
         """
@@ -52,12 +54,14 @@ class OpenSlideReader(ImageReader):
         :param input_path: The path to the OpenSlide image
 
         """
-        self._ctx = _get_ctx(ctx, config)
-        self._cfg = self._ctx.config()
+        self._source_ctx = _get_ctx(source_ctx, source_config)
+        self._source_cfg = self._source_ctx.config()
+        self._dest_ctx = _get_ctx(dest_ctx, dest_config)
+        self._dest_cfg = self._dest_ctx.config()
         self._logger = get_logger_wrapper(False) if not logger else logger
         if is_remote_protocol(input_path):
             resolved_path = cache_filepath(
-                input_path, config, ctx, self._logger, scratch_space
+                input_path, source_config, source_ctx, self._logger, scratch_space
             )
         else:
             resolved_path = input_path
@@ -67,8 +71,12 @@ class OpenSlideReader(ImageReader):
         self._osd.close()
 
     @property
-    def ctx(self) -> Ctx:
-        return self._ctx
+    def source_ctx(self) -> Ctx:
+        return self._source_ctx
+
+    @property
+    def dest_ctx(self) -> Ctx:
+        return self._dest_ctx
 
     @property
     def logger(self) -> Optional[logging.Logger]:

--- a/tiledb/bioimg/wrappers.py
+++ b/tiledb/bioimg/wrappers.py
@@ -47,7 +47,18 @@ def from_bioimg(
     :param kwargs: keyword arguments for custom ingestion behaviour
     :return: The converter class that was used for the ingestion
     """
+
     logger = get_logger_wrapper(verbose)
+    reader_kwargs = kwargs.get("reader_kwargs", {})
+
+    # Get the config for the source
+    reader_kwargs["source_config"] = kwargs.pop("source_config", None)
+
+    # Get the config for the destination (if exists) otherwise match it with source config
+    reader_kwargs["dest_config"] = kwargs.pop(
+        "dest_config", reader_kwargs["source_config"]
+    )
+
     if converter is Converters.OMETIFF:
         if not _tiff_exc:
             logger.info("Converting OME-TIFF file")
@@ -57,6 +68,7 @@ def from_bioimg(
                 log=logger,
                 exclude_metadata=exclude_metadata,
                 tile_scale=tile_scale,
+                reader_kwargs=reader_kwargs,
                 **kwargs,
             )
         else:
@@ -70,6 +82,7 @@ def from_bioimg(
                 log=logger,
                 exclude_metadata=exclude_metadata,
                 tile_scale=tile_scale,
+                reader_kwargs=reader_kwargs,
                 **kwargs,
             )
         else:
@@ -83,6 +96,7 @@ def from_bioimg(
                 log=logger,
                 exclude_metadata=exclude_metadata,
                 tile_scale=tile_scale,
+                reader_kwargs=reader_kwargs,
                 **kwargs,
             )
         else:


### PR DESCRIPTION
This PR:

- Adds support for separate source `config` and destination `config` for the ingestion.

**Depends on `tiledb-py==0.30.3` release**