### PR TITLE
Exported images fail to render in qupath

### DIFF
--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,3 +1,5 @@
+import xml.etree.ElementTree as ET
+
 import numpy as np
 import pytest
 
@@ -67,10 +69,25 @@ def test_remove_ome_image_metadata(macro, has_label, num_images, root_tag):
     original_xml_string = generate_xml(
         has_macro=macro, has_label=has_label, num_images=1, root_tag=root_tag
     )
+
+    excluded_metadata = remove_ome_image_metadata(original_xml_string)
     if root_tag == "OME":
+        parsed_excluded = ET.fromstring(excluded_metadata)
+
+        # Assert if "label" subelement is present
         assert (
-            remove_ome_image_metadata(original_xml_string)
-            == '<ns0:OME xmlns:ns0="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Creator="tifffile.py 2023.7.4" UUID="urn:uuid:40348664-c1f8-11ee-a19b-58112295faaf" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"><ns0:Instrument ID="Instrument:95"><ns0:Objective ID="Objective:95" NominalMagnification="40.0" /></ns0:Instrument><ns0:Image ID="Image:0" Name="Image0"><ns0:Pixels DimensionOrder="XYCZT" ID="Pixels:0" SizeC="3" SizeT="1" SizeX="86272" SizeY="159488" SizeZ="1" Type="uint8" Interleaved="true" PhysicalSizeX="0.2827" PhysicalSizeY="0.2827"><ns0:Channel ID="Channel:0:0" SamplesPerPixel="3" /><ns0:TiffData PlaneCount="1" /></ns0:Pixels></ns0:Image></ns0:OME>'
+            parsed_excluded.find(
+                ".//{http://www.openmicroscopy.org/Schemas/OME/2016-06}Image[@ID='Image:label'][@Name='label']"
+            )
+            is None
+        )
+
+        # Assert if "macro" subelement is present
+        assert (
+            parsed_excluded.find(
+                ".//{http://www.openmicroscopy.org/Schemas/OME/2016-06}Image[@ID='Image:macro'][@Name='macro']"
+            )
+            is None
         )
     else:
         assert remove_ome_image_metadata(original_xml_string) is None

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -51,6 +51,7 @@ from ..helpers import (
     iter_levels_meta,
     iter_pixel_depths_meta,
     open_bioimg,
+    remove_ome_image_metadata,
     resolve_path,
     validate_ingestion,
 )
@@ -512,6 +513,12 @@ class ImageConverterMixin(Generic[TReader, TWriter]):
 
             if not exclude_metadata:
                 original_metadata = reader.original_metadata
+            else:
+                if ome_xml := reader.original_metadata.get("ome_metadata"):
+                    pruned_metadata = remove_ome_image_metadata(ome_xml)
+                    original_metadata = (
+                        {"ome_metadata": pruned_metadata} if pruned_metadata else {}
+                    )
 
         with rw_group:
             rw_group.w_group.meta.update(

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -34,7 +34,12 @@ from tiledb.cc import WebpInputFormat
 from tiledb.highlevel import _get_ctx
 
 from .. import ATTR_NAME, EXPORT_TILE_SIZE, WHITE_RGBA
-from ..helpers import get_decimal_from_rgba, get_logger_wrapper, get_rgba, iter_color
+from ..helpers import (
+    get_decimal_from_rgba,
+    get_logger_wrapper,
+    get_rgba,
+    iter_color,
+)
 from .axes import Axes
 from .base import ImageConverterMixin
 from .io import as_array

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -482,4 +482,7 @@ def remove_ome_image_metadata(xml_string: str) -> Union[str, Any]:
             root.remove(image)
 
     # Return the modified XML as a string
-    return ET.tostring(root, encoding="unicode")
+    return ET.tostring(
+        root,
+        encoding="unicode",
+    )

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -461,7 +462,12 @@ def merge_ned_ranges(
 
 
 def remove_ome_image_metadata(xml_string: str) -> Union[str, Any]:
-
+    """
+    This functions parses an OME-XML file and removes the `macro` and `label` metadata
+    of the image that it accompanies.
+    :param xml_string: OME-XML string to remove metadata from
+    :return: OME-XML string with metadata removed
+    """
     if not xml_string.lstrip().startswith("<OME") or not xml_string:
         return None
 
@@ -482,7 +488,15 @@ def remove_ome_image_metadata(xml_string: str) -> Union[str, Any]:
             root.remove(image)
 
     # Return the modified XML as a string
-    return ET.tostring(
-        root,
-        encoding="unicode",
+    # Regular expression pattern to match 'ns0', 'ns0:', or ':ns0'
+    pattern = r"ns0:|:ns0|ns0"
+
+    # Substitute the matches with an empty string
+    return re.sub(
+        pattern,
+        "",
+        ET.tostring(
+            root,
+            encoding="unicode",
+        ),
     )


### PR DESCRIPTION
Problem statement:
You can find it in the shortcut ticket.

This PR:

- Parses the OME-XML metadata and instead of removing it as a whole it removes only the metadata for the `macro` and `label` images. Leaving the OME-XML metadata structure solves the issue with Qupath and the latter can select the correct reader for rendering an exported image.

