### PR TITLE
Support for biomedical image formats NIFTI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@ import setuptools
 zarr = ["ome-zarr>=0.9.0"]
 openslide = ["openslide-python"]
 tiff = ["tifffile", "imagecodecs"]
+nifti = ["nibabel"]
 cloud = ["tiledb-cloud"]
 
-full = sorted({*zarr, *openslide, *tiff})
+full = sorted({*zarr, *openslide, *tiff, *nifti})
 setuptools.setup(
     setup_requires=["setuptools_scm"],
     use_scm_version={
@@ -25,6 +26,7 @@ setuptools.setup(
         "zarr": zarr,
         "openslide": openslide,
         "tiff": tiff,
+        "nifti": nifti,
         "cloud": cloud,
         "full": full,
     },
@@ -34,17 +36,20 @@ setuptools.setup(
             "zarr_reader = tiledb.bioimg.converters.ome_zarr:OMEZarrReader",
             "osd_reader = tiledb.bioimg.converters.openslide:OpenSlideReader",
             "png_reader = tiledb.bioimg.converters.png.PNGReader",
+            "nifti_reader = tiledb.bioimg.converters.nifti:NiftiReader",
         ],
         "bioimg.writers": [
             "tiff_writer = tiledb.bioimg.converters.ome_tiff:OMETiffWriter",
             "zarr_writer = tiledb.bioimg.converters.ome_tiff:OMEZarrWriter",
             "png_writer = tiledb.bioimg.converters.png.PNGWriter",
+            "nifti_writer = tiledb.bioimg.converters.nifti:NiftiWriter",
         ],
         "bioimg.converters": [
             "tiff_converter = tiledb.bioimg.converters.ome_tiff:OMETiffConverter",
             "zarr_converter = tiledb.bioimg.converters.ome_zarr:OMEZarrConverter",
             "osd_converter = tiledb.bioimg.converters.openslide:OpenSlideConverter",
             "png_converter = tiledb.bioimg.converters.png:PNGConverter",
+            "nifti_converter = tiledb.bioimg.converters.nifti:NiftiConverter",
         ],
     },
 )

--- a/tiledb/bioimg/types.py
+++ b/tiledb/bioimg/types.py
@@ -6,3 +6,4 @@ class Converters(enum.Enum):
     OMEZARR = enum.auto()
     OSD = enum.auto()
     PNG = enum.auto()
+    NIFTI = enum.auto()


### PR DESCRIPTION
This draft PR:

- Adds support for NIFTI images in TileDB-Bioimaging
- Roundtrip has been tested and is working using the `from_bioimg`, `to_bioimg` API calls and the respective `Converter.Nifti`
- The original & exported images are renderable by `Slicer`
- [TB-Added] Unit-tests
- [TB-Added] Other sample images apart from `visiblehuman`
- [TB-Investigated] Differences between `Nifti1Images` and `Nifti2Images`