### PR TITLE
Adding a metadata flag for signaling successful ingestion

### DIFF
--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -420,6 +420,10 @@ class ImageConverterMixin(Generic[TReader, TWriter]):
                 # Overwrite destination group
                 rw_group.m_group.delete(recursive=True)
                 overwrite = True
+            else:
+                # If group is valid we remove the KV and we will re-introduce it
+                # after the current ingestion process as the final step
+                del rw_group.w_group.meta["valid"]
 
         if overwrite:
             # Re-initializes the destination Group for re-ingestion


### PR DESCRIPTION
This PR:

- Adds a metadata KV at a group level of an ingested image signalling if the ingestion was completed successfully after all the steps.
- The metadata key `valid` gets a boolean value of either `True` or `False`
- During every ingestion a check is being performed to find if the desination path already exists and is a group. In this scenario we check if the group's metadata contain the key `valid`. If not this signals a corrupted ingested file (possibly from a previous run) and the response to that is for the group to be overwritten from scratch.
- In case the group exists but the ingestion runs in order for more layers to be added into the image `incremental ingestion` the flag is not enabled. We initially remove again the `valid` KV from the group's metadata until re-instantiate at the end of the current ingestion that is being running.