### PR TITLE
Use exposed type instead of internal

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,7 @@ from skimage.metrics import structural_similarity
 
 import tiledb
 from tiledb.bioimg import ATTR_NAME
-from tiledb.libtiledb import WebpInputFormat
+from tiledb.filter import WebpFilter
 from tiledb.bioimg.helpers import merge_ned_ranges
 import xml.etree.ElementTree as ET
 
@@ -24,11 +24,11 @@ def get_schema(x_size, y_size, c_size=3, compressor=tiledb.ZstdFilter(level=0)):
     if isinstance(compressor, tiledb.WebpFilter):
         x_size *= c_size
         x_tile *= c_size
-        if compressor.input_format == WebpInputFormat.WEBP_NONE:
+        if compressor.input_format == WebpFilter.WebpInputFormat.WEBP_NONE:
             if c_size == 3:
-                input_format = WebpInputFormat.WEBP_RGB
+                input_format = WebpFilter.WebpInputFormat.WEBP_RGB
             elif c_size == 4:
-                input_format = WebpInputFormat.WEBP_RGBA
+                input_format = WebpFilter.WebpInputFormat.WEBP_RGBA
             else:
                 assert False, f"No WebpInputFormat with pixel_depth={c_size}"
             compressor = tiledb.WebpFilter(

--- a/tests/integration/converters/test_ome_tiff.py
+++ b/tests/integration/converters/test_ome_tiff.py
@@ -12,7 +12,7 @@ from tiledb.bioimg.converters import DATASET_TYPE, FMT_VERSION
 from tiledb.bioimg.converters.ome_tiff import OMETiffConverter
 from tiledb.bioimg.helpers import open_bioimg
 from tiledb.bioimg.openslide import TileDBOpenSlide
-from tiledb.libtiledb import WebpInputFormat
+from tiledb.filter import WebpFilter
 
 
 def test_ome_tiff_converter(tmp_path):
@@ -101,9 +101,9 @@ def test_ome_tiff_converter_group_metadata(tmp_path, filename):
     "compressor",
     [
         tiledb.ZstdFilter(level=0),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=False),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=True),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_NONE, lossless=True),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=False),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=True),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_NONE, lossless=True),
     ],
 )
 def test_ome_tiff_converter_exclude_original_metadata(
@@ -138,9 +138,9 @@ def test_ome_tiff_converter_exclude_original_metadata(
     "compressor",
     [
         tiledb.ZstdFilter(level=0),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=False),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=True),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_NONE, lossless=True),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=False),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=True),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_NONE, lossless=True),
     ],
 )
 def test_ome_tiff_converter_roundtrip(
@@ -235,8 +235,8 @@ def compare_tiff(t1: tifffile.TiffFile, t2: tifffile.TiffFile, lossless: bool = 
 compressors = [
     None,
     tiledb.ZstdFilter(level=0),
-    tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=False),
-    tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=True),
+    tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=False),
+    tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=True),
 ]
 
 

--- a/tests/integration/converters/test_ome_tiff_experimental.py
+++ b/tests/integration/converters/test_ome_tiff_experimental.py
@@ -7,7 +7,7 @@ from tests import assert_image_similarity, get_path
 from tiledb.bioimg.converters.ome_tiff import OMETiffConverter
 from tiledb.bioimg.helpers import open_bioimg
 from tiledb.bioimg.openslide import TileDBOpenSlide
-from tiledb.libtiledb import WebpInputFormat
+from tiledb.filter import WebpFilter
 
 
 # We need to expand on the test files. Most of the test files we have currently are not memory
@@ -169,6 +169,6 @@ def compare_tiff(t1: tifffile.TiffFile, t2: tifffile.TiffFile, lossless: bool = 
 compressors = [
     None,
     tiledb.ZstdFilter(level=0),
-    tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=False),
-    tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=True),
+    tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=False),
+    tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=True),
 ]

--- a/tests/integration/converters/test_ome_zarr.py
+++ b/tests/integration/converters/test_ome_zarr.py
@@ -11,7 +11,7 @@ from tiledb.bioimg.converters import DATASET_TYPE, FMT_VERSION
 from tiledb.bioimg.converters.ome_zarr import OMEZarrConverter
 from tiledb.bioimg.helpers import iter_color, open_bioimg
 from tiledb.bioimg.openslide import TileDBOpenSlide
-from tiledb.libtiledb import WebpInputFormat
+from tiledb.filter import WebpFilter
 
 schemas = (get_schema(2220, 2967), get_schema(387, 463), get_schema(1280, 431))
 
@@ -98,9 +98,9 @@ def test_ome_zarr_converter(tmp_path, series_idx, preserve_axes):
     "compressor",
     [
         tiledb.ZstdFilter(level=0),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=False),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=True),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_NONE, lossless=True),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=False),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=True),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_NONE, lossless=True),
     ],
 )
 def test_ome_zarr_converter_rountrip(

--- a/tests/integration/converters/test_openslide.py
+++ b/tests/integration/converters/test_openslide.py
@@ -10,7 +10,7 @@ from tiledb.bioimg.converters import DATASET_TYPE, FMT_VERSION
 from tiledb.bioimg.converters.openslide import OpenSlideConverter
 from tiledb.bioimg.helpers import open_bioimg
 from tiledb.bioimg.openslide import TileDBOpenSlide
-from tiledb.libtiledb import WebpInputFormat
+from tiledb.filter import WebpFilter
 
 
 @pytest.mark.parametrize("preserve_axes", [False, True])
@@ -19,9 +19,9 @@ from tiledb.libtiledb import WebpInputFormat
     "compressor",
     [
         tiledb.ZstdFilter(level=0),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_RGBA, lossless=False),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_RGBA, lossless=True),
-        tiledb.WebpFilter(WebpInputFormat.WEBP_NONE, lossless=True),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGBA, lossless=False),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGBA, lossless=True),
+        tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_NONE, lossless=True),
     ],
 )
 def test_openslide_converter(tmp_path, preserve_axes, chunked, max_workers, compressor):

--- a/tests/integration/converters/test_png.py
+++ b/tests/integration/converters/test_png.py
@@ -10,7 +10,7 @@ from tiledb.bioimg.converters import DATASET_TYPE, FMT_VERSION
 from tiledb.bioimg.converters.png import PNGConverter
 from tiledb.bioimg.helpers import open_bioimg
 from tiledb.bioimg.openslide import TileDBOpenSlide
-from tiledb.libtiledb import WebpInputFormat
+from tiledb.filter import WebpFilter
 
 
 def create_synthetic_image(
@@ -125,8 +125,8 @@ def compare_png(p1: Image, p2: Image, lossless: bool = True):
     "compressor, lossless",
     [
         (tiledb.ZstdFilter(level=0), True),
-        (tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=True), True),
-        (tiledb.WebpFilter(WebpInputFormat.WEBP_NONE, lossless=True), True),
+        (tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=True), True),
+        (tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_NONE, lossless=True), True),
     ],
 )
 @pytest.mark.parametrize(
@@ -196,7 +196,7 @@ def test_png_converter_L_roundtrip(
 @pytest.mark.parametrize(
     "compressor, lossless",
     [
-        (tiledb.WebpFilter(WebpInputFormat.WEBP_RGB, lossless=False), False),
+        (tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGB, lossless=False), False),
     ],
 )
 def test_png_converter_RGB_roundtrip_lossy(
@@ -235,8 +235,8 @@ def test_png_converter_RGB_roundtrip_lossy(
     "compressor, lossless",
     [
         (tiledb.ZstdFilter(level=0), True),
-        (tiledb.WebpFilter(WebpInputFormat.WEBP_RGBA, lossless=True), True),
-        (tiledb.WebpFilter(WebpInputFormat.WEBP_NONE, lossless=True), True),
+        (tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGBA, lossless=True), True),
+        (tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_NONE, lossless=True), True),
     ],
 )
 def test_png_converter_RGBA_roundtrip(
@@ -266,7 +266,10 @@ def test_png_converter_RGBA_roundtrip(
 @pytest.mark.parametrize(
     "compressor, lossless",
     [
-        (tiledb.WebpFilter(WebpInputFormat.WEBP_RGBA, lossless=False), False),
+        (
+            tiledb.WebpFilter(WebpFilter.WebpInputFormat.WEBP_RGBA, lossless=False),
+            False,
+        ),
     ],
 )
 def test_png_converter_RGBA_roundtrip_lossy(

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -37,7 +37,7 @@ except ImportError:
     register_group = None
 
 import tiledb
-from tiledb.libtiledb import WebpInputFormat
+from tiledb.filter import WebpFilter
 
 from .. import ATTR_NAME
 from ..helpers import (
@@ -99,9 +99,9 @@ class ImageReader(Protocol):
         ...
 
     @property
-    def webp_format(self) -> WebpInputFormat:
+    def webp_format(self) -> WebpFilter.WebpInputFormat:
         """WebpInputFormat of this multi-resolution image. Defaults to WEBP_NONE."""
-        return WebpInputFormat.WEBP_NONE
+        return WebpFilter.WebpInputFormat.WEBP_NONE
 
     @property
     def level_count(self) -> int:
@@ -457,7 +457,8 @@ class ImageConverterMixin(Generic[TReader, TWriter]):
                 elif isinstance(compressor, tiledb.Filter):
                     if (
                         isinstance(compressor, tiledb.WebpFilter)
-                        and compressor.input_format == WebpInputFormat.WEBP_NONE
+                        and compressor.input_format
+                        == WebpFilter.WebpInputFormat.WEBP_NONE
                     ):
                         compressor = tiledb.WebpFilter(
                             input_format=reader.webp_format,

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -30,8 +30,8 @@ except ImportError as err:
     raise err
 
 from tiledb import VFS, Config, Ctx
+from tiledb.filter import WebpFilter
 from tiledb.highlevel import _get_ctx
-from tiledb.libtiledb import WebpInputFormat
 
 from .. import ATTR_NAME, EXPORT_TILE_SIZE, WHITE_RGBA
 from ..helpers import (
@@ -114,12 +114,12 @@ class OMETiffReader:
     @property
     def channels(self) -> Sequence[str]:
         # channel names are fixed if this is an RGB image
-        if self.webp_format is WebpInputFormat.WEBP_RGB:
-            self._logger.debug(f"Webp format: {WebpInputFormat.WEBP_RGB}")
+        if self.webp_format is WebpFilter.WebpInputFormat.WEBP_RGB:
+            self._logger.debug(f"Webp format: {WebpFilter.WebpInputFormat.WEBP_RGB}")
             return "RED", "GREEN", "BLUE"
 
         # otherwise try to infer them from the OME-XML metadata
-        self._logger.debug(f"Webp format is not: {WebpInputFormat.WEBP_RGB}")
+        self._logger.debug(f"Webp format is not: {WebpFilter.WebpInputFormat.WEBP_RGB}")
         try:
             channels = self._metadata["OME"]["Image"][0]["Pixels"]["Channel"]
             if not isinstance(channels, Sequence):
@@ -130,16 +130,16 @@ class OMETiffReader:
         return tuple(c.get("Name") or f"Channel {i}" for i, c in enumerate(channels))
 
     @property
-    def webp_format(self) -> WebpInputFormat:
+    def webp_format(self) -> WebpFilter.WebpInputFormat:
         self._logger.debug(f"Keyframe photometric: {self._series.keyframe.photometric}")
         if self._series.keyframe.photometric == tifffile.PHOTOMETRIC.RGB:
-            return WebpInputFormat.WEBP_RGB
+            return WebpFilter.WebpInputFormat.WEBP_RGB
         # XXX: it is possible that instead of a single RGB channel (samplesperpixel==3)
         # there are 3 MINISBLACK channels (samplesperpixel=1). In this case look for the
         # photometric interpretation in the original metadata
         if self._original_metadata("PhotometricInterpretation") == "RGB":
-            return WebpInputFormat.WEBP_RGB
-        return WebpInputFormat.WEBP_NONE
+            return WebpFilter.WebpInputFormat.WEBP_RGB
+        return WebpFilter.WebpInputFormat.WEBP_NONE
 
     @property
     def level_count(self) -> int:

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -32,8 +32,8 @@ except ImportError as err:
     raise err
 
 from tiledb import Config, Ctx
+from tiledb.filter import WebpFilter
 from tiledb.highlevel import _get_ctx
-from tiledb.libtiledb import WebpInputFormat
 
 from .. import WHITE_RGB
 from ..helpers import get_logger_wrapper, get_rgba, translate_config_to_s3fs
@@ -105,14 +105,14 @@ class OMEZarrReader:
         )
 
     @property
-    def webp_format(self) -> WebpInputFormat:
+    def webp_format(self) -> WebpFilter.WebpInputFormat:
         channels = self._omero.image_data.get("channels", ()) if self._omero else ()
         colors = tuple(channel.get("color") for channel in channels)
         self._logger.debug(f"Webp format - channels: {channels},  colors:{colors}")
 
         if colors == ("FF0000", "00FF00", "0000FF"):
-            return WebpInputFormat.WEBP_RGB
-        return WebpInputFormat.WEBP_NONE
+            return WebpFilter.WebpInputFormat.WEBP_RGB
+        return WebpFilter.WebpInputFormat.WEBP_NONE
 
     @property
     def level_count(self) -> int:

--- a/tiledb/bioimg/converters/openslide.py
+++ b/tiledb/bioimg/converters/openslide.py
@@ -8,8 +8,8 @@ import openslide as osd
 from numpy._typing import NDArray
 
 from tiledb import Config, Ctx
+from tiledb.filter import WebpFilter
 from tiledb.highlevel import _get_ctx
-from tiledb.libtiledb import WebpInputFormat
 
 from ..helpers import cache_filepath, get_logger_wrapper, is_remote_protocol, iter_color
 from . import DEFAULT_SCRATCH_SPACE
@@ -79,9 +79,9 @@ class OpenSlideReader:
         return "RED", "GREEN", "BLUE", "ALPHA"
 
     @property
-    def webp_format(self) -> WebpInputFormat:
-        self._logger.debug(f"Webp Input Format: {WebpInputFormat.WEBP_RGBA}")
-        return WebpInputFormat.WEBP_RGBA
+    def webp_format(self) -> WebpFilter.WebpInputFormat:
+        self._logger.debug(f"Webp Input Format: {WebpFilter.WebpInputFormat.WEBP_RGBA}")
+        return WebpFilter.WebpInputFormat.WEBP_RGBA
 
     @property
     def level_count(self) -> int:

--- a/tiledb/bioimg/converters/png.py
+++ b/tiledb/bioimg/converters/png.py
@@ -18,8 +18,8 @@ from numpy._typing import NDArray
 from PIL import Image
 
 from tiledb import VFS, Config, Ctx
+from tiledb.filter import WebpFilter
 from tiledb.highlevel import _get_ctx
-from tiledb.libtiledb import WebpInputFormat
 
 from ..helpers import get_logger_wrapper, iter_color
 from .axes import Axes
@@ -89,15 +89,15 @@ class PNGReader:
 
     @property
     def channels(self) -> Sequence[str]:
-        if self.webp_format is WebpInputFormat.WEBP_RGB:
-            self._logger.debug(f"Webp format: {WebpInputFormat.WEBP_RGB}")
+        if self.webp_format is WebpFilter.WebpInputFormat.WEBP_RGB:
+            self._logger.debug(f"Webp format: {WebpFilter.WebpInputFormat.WEBP_RGB}")
             return "RED", "GREEN", "BLUE"
-        elif self.webp_format is WebpInputFormat.WEBP_RGBA:
-            self._logger.debug(f"Webp format: {WebpInputFormat.WEBP_RGBA}")
+        elif self.webp_format is WebpFilter.WebpInputFormat.WEBP_RGBA:
+            self._logger.debug(f"Webp format: {WebpFilter.WebpInputFormat.WEBP_RGBA}")
             return "RED", "GREEN", "BLUE", "ALPHA"
         else:
             self._logger.debug(
-                f"Webp format is not: {WebpInputFormat.WEBP_RGB} / {WebpInputFormat.WEBP_RGBA}"
+                f"Webp format is not: {WebpFilter.WebpInputFormat.WEBP_RGB} / {WebpFilter.WebpInputFormat.WEBP_RGBA}"
             )
         color_map = {
             "R": "RED",
@@ -142,13 +142,13 @@ class PNGReader:
         return l_shape
 
     @property
-    def webp_format(self) -> WebpInputFormat:
+    def webp_format(self) -> WebpFilter.WebpInputFormat:
         self._logger.debug(f"Channel Mode: {self._png.mode}")
         if self._png.mode == "RGB":
-            return WebpInputFormat.WEBP_RGB
+            return WebpFilter.WebpInputFormat.WEBP_RGB
         elif self._png.mode == "RGBA":
-            return WebpInputFormat.WEBP_RGBA
-        return WebpInputFormat.WEBP_NONE
+            return WebpFilter.WebpInputFormat.WEBP_RGBA
+        return WebpFilter.WebpInputFormat.WEBP_NONE
 
     def level_image(
         self, level: int = 0, tile: Optional[Tuple[slice, ...]] = None

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -24,7 +24,7 @@ import numpy as np
 
 import tiledb
 from tiledb import Config, Ctx
-from tiledb.libtiledb import WebpInputFormat
+from tiledb.filter import WebpFilter
 
 from . import ATTR_NAME
 from .converters.axes import Axes, AxesMapper
@@ -238,11 +238,17 @@ def get_pixel_depth(compressor: tiledb.Filter) -> int:
     if not isinstance(compressor, tiledb.WebpFilter):
         return 1
     webp_format = compressor.input_format
-    if webp_format in (WebpInputFormat.WEBP_RGB, WebpInputFormat.WEBP_BGR):
+    if webp_format in (
+        WebpFilter.WebpInputFormat.WEBP_RGB,
+        WebpFilter.WebpInputFormat.WEBP_BGR,
+    ):
         return 3
-    if webp_format in (WebpInputFormat.WEBP_RGBA, WebpInputFormat.WEBP_BGRA):
+    if webp_format in (
+        WebpFilter.WebpInputFormat.WEBP_RGBA,
+        WebpFilter.WebpInputFormat.WEBP_BGRA,
+    ):
         return 4
-    raise ValueError(f"Invalid WebpInputFormat: {compressor.input_format}")
+    raise ValueError(f"Invalid WebpFilter.WebpInputFormat: {compressor.input_format}")
 
 
 def get_axes_translation(


### PR DESCRIPTION
In https://github.com/TileDB-Inc/TileDB-BioImaging/pull/147, the import of `WebpInputFormat` type was changed from `from tiledb.cc import WebpInputFormat` to `from tiledb.libtiledb import WebpInputFormat`, as https://github.com/TileDB-Inc/TileDB-Py/pull/2123 renamed `cc` to `libtiledb`. This change caused backward compatibility issues. 

To resolve the issue, this PR uses the exposed type instead of the internal one. 

Furthermore, to generally address similar issues without requiring code changes, an alias has been provided: https://github.com/TileDB-Inc/TileDB-Py/pull/2145.