### PR TITLE
Updating runner's ubuntu version due to deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         sys:
           - { os: windows-latest, shell: 'cmd /C call {0}' }
-          - { os: ubuntu-latest,  shell: "bash -l {0}" }
+          - { os: ubuntu-24.04,  shell: "bash -l {0}" }
       fail-fast: false
     defaults:
       run:
@@ -98,7 +98,7 @@ jobs:
         micromamba run -n test pytest --nbmake examples
 
     - name: Create Test Coverage Badge
-      if: ${{ env.run_coverage == 'true' && matrix.sys.os == 'ubuntu-latest' }}
+      if: ${{ env.run_coverage == 'true' && matrix.sys.os == 'ubuntu-24.04' }}
       uses: schneegans/dynamic-badges-action@v1.7.0
       with:
         auth: ${{ secrets.COVERAGE_SECRET }}


### PR DESCRIPTION
This PR:

- Updates the ubuntu version of CI runners due to upcoming deprecation as noted [actions/runner-images#11101](https://github.com/actions/runner-images/issues/11101).