### PR TITLE
Transforming custom axes to canonical up to 5D

### DIFF
--- a/tests/unit/test_axes.py
+++ b/tests/unit/test_axes.py
@@ -92,10 +92,6 @@ class TestAxes:
         assert Axes("XYZ").dims == "XYZ"
 
         with pytest.raises(ValueError) as excinfo:
-            Axes("XYZW")
-        assert str(excinfo.value) == "'W' is not a valid Axis"
-
-        with pytest.raises(ValueError) as excinfo:
             Axes("XYZX")
         assert "Duplicate axes" in str(excinfo.value)
 


### PR DESCRIPTION
This PR:

- Changes the internal management of custom named axes. Instead of raising `ValueError` when axes names do not fall under the canonical axes names' convention, we now rename this custom axis to a `standard` axis name that is available excluding the required axes names `X`, `Y` and `C`. If there is no availability then we throw the error.

The behaviour is bounded to support cases up to 5D images, as it is already supported. With a future change we want to totally decouple the axes names from the need of following a canonical convention.