### PR TITLE
Bioimg package dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,25 +37,6 @@ jobs:
           pre-commit
           pytest-cov
           pytest-mock
-    
-#    - name: Install openslide for non-Win
-#      run: |
-#        sudo apt install openslide-tools
-#        micromamba install openslide
-#        echo ${{ matrix.sys.os }}
-#      if: ${{ matrix.sys.os != 'windows-latest' }}
-#
-#    - name: Install openslide for Win
-#      run: |
-#        choco install wget --no-progress
-#        wget https://github.com/openslide/openslide-winbuild/releases/download/v20221217/openslide-win64-20221217.zip
-#        7z x openslide-win64-20221217.zip -oD:\openslide\
-#        mklink /D C:\openslide-win64\ D:\openslide\openslide-win64-20221217\
-#        cd C:\openslide-win64\
-#        dir
-#        set openslide_path=%cd%
-#        echo %openslide_path%
-#      if: ${{ matrix.sys.os == 'windows-latest' }}
 
     - name: Run pre-commit hooks
       run: | 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,24 +38,24 @@ jobs:
           pytest-cov
           pytest-mock
     
-    - name: Install openslide for non-Win
-      run: |
-        sudo apt install openslide-tools
-        micromamba install openslide
-        echo ${{ matrix.sys.os }}
-      if: ${{ matrix.sys.os != 'windows-latest' }}
-
-    - name: Install openslide for Win 
-      run: |
-        choco install wget --no-progress
-        wget https://github.com/openslide/openslide-winbuild/releases/download/v20221217/openslide-win64-20221217.zip
-        7z x openslide-win64-20221217.zip -oD:\openslide\
-        mklink /D C:\openslide-win64\ D:\openslide\openslide-win64-20221217\
-        cd C:\openslide-win64\
-        dir
-        set openslide_path=%cd%
-        echo %openslide_path%
-      if: ${{ matrix.sys.os == 'windows-latest' }}
+#    - name: Install openslide for non-Win
+#      run: |
+#        sudo apt install openslide-tools
+#        micromamba install openslide
+#        echo ${{ matrix.sys.os }}
+#      if: ${{ matrix.sys.os != 'windows-latest' }}
+#
+#    - name: Install openslide for Win
+#      run: |
+#        choco install wget --no-progress
+#        wget https://github.com/openslide/openslide-winbuild/releases/download/v20221217/openslide-win64-20221217.zip
+#        7z x openslide-win64-20221217.zip -oD:\openslide\
+#        mklink /D C:\openslide-win64\ D:\openslide\openslide-win64-20221217\
+#        cd C:\openslide-win64\
+#        dir
+#        set openslide_path=%cd%
+#        echo %openslide_path%
+#      if: ${{ matrix.sys.os == 'windows-latest' }}
 
     - name: Run pre-commit hooks
       run: | 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ Python package for:
 - [TileDB Cloud](https://cloud.tiledb.com) includes a built-in, pyramidal multi-resolution viewer: log in to TileDB Cloud to see an example image preview [here](https://cloud.tiledb.com/biomedical-imaging/TileDB-Inc/dbb7dfcc-28b3-40e5-916f-6509a666d950/preview)
 - Napari: https://github.com/TileDB-Inc/napari-tiledb-bioimg
 
-## Installation Prerequisites
-
-OpenSlide Python requires that OpenSlide be installed separately prior to its installation.
-
-Prior to proceeding with the below installation instructions, please [install OpenSlide as recommended by the OpenSlide Python library](https://openslide.org/api/python/#:~:text=OpenSlide%20Python%20requires%20OpenSlide%2C%20which%20must%20be%20installed%20separately).
-
 ## Quick Installation
 
 - From PyPI:
@@ -43,22 +37,6 @@ Prior to proceeding with the below installation instructions, please [install Op
       cd TileDB-BioImaging
 
       pip install -e '.[full]'
-
-## Windows Installation
-
-After installing `Openslide` you should make sure that you create a link between your installation path and
-the following default path `C:\openslide-win64\ `.
-
-```cmd
-mklink /D C:\openslide-win64\ [your-installation-path]\openslide-win64-20221217\
-```
-
-You can install the latest versions of `Openslide` for windows using the pre-built packages
-found in the project's github page:
-`https://github.com/openslide/openslide-bin/releases`
-
-or in their website:
-`https://openslide.org/download/`
 
 
 ## Examples

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
         "write_to": "tiledb/bioimg/version.py",
     },
     install_requires=[
+        "openslide-bin",
         "pyeditdistance",
         "tiledb>=0.19",
         "tqdm",

--- a/tests/integration/converters/__init__.py
+++ b/tests/integration/converters/__init__.py
@@ -1,6 +1,1 @@
-import os
-from tiledb.bioimg import WIN_OPENSLIDE_PATH
 
-if hasattr(os, "add_dll_directory"):
-    # Python >= 3.8 on Windows
-    os.add_dll_directory(WIN_OPENSLIDE_PATH)

--- a/tiledb/bioimg/__init__.py
+++ b/tiledb/bioimg/__init__.py
@@ -2,39 +2,22 @@ ATTR_NAME = "intensity"
 WHITE_RGB = 16777215  # FFFFFF in hex
 WHITE_RGBA = 4294967295  # FFFFFFFF in hex
 EXPORT_TILE_SIZE = 256
-WIN_OPENSLIDE_PATH = r"C:\openslide-win64\bin"
 
 import importlib.util
-import os
 import warnings
 from typing import Optional
 from .types import Converters
 
 _osd_exc: Optional[ImportError]
-
-if hasattr(os, "add_dll_directory"):
-    # Python >= 3.8 on Windows
-    with os.add_dll_directory(WIN_OPENSLIDE_PATH):
-        try:
-            importlib.util.find_spec("openslide")
-        except ImportError as err_osd:
-            warnings.warn(
-                "Openslide Converter requires 'openslide-python' package. "
-                "You can install 'tiledb-bioimg' with the 'openslide' or 'full' flag"
-            )
-            _osd_exc = err_osd
-        else:
-            _osd_exc = None
+try:
+    importlib.util.find_spec("openslide")
+except ImportError as err_osd:
+    warnings.warn(
+        "Openslide Converter requires 'openslide-python' package. "
+        "You can install 'tiledb-bioimg' with the 'openslide' or 'full' flag"
+    )
+    _osd_exc = err_osd
 else:
-    try:
-        importlib.util.find_spec("openslide")
-    except ImportError as err_osd:
-        warnings.warn(
-            "Openslide Converter requires 'openslide-python' package. "
-            "You can install 'tiledb-bioimg' with the 'openslide' or 'full' flag"
-        )
-        _osd_exc = err_osd
-    else:
-        _osd_exc = None
+    _osd_exc = None
 
 from .wrappers import *


### PR DESCRIPTION
This PR:

- In the past `openslide-python` required the installation of the `openslide` library, which was system dependent.
- With `openslide-bin` introduction and python3.8+ we avoid any manual setup for the different systems we support (Linux, Darwin and Windows)
- Adds the `openslide-bin` as a project dependency
- `Openslide-python` is now automatically find the installation of the `openslide` binaries.
- Removes deprecated ReadMe.md installation instructions
- CI steps for installing the `openslide` binaries on different setups.