### PR TITLE
Support generic tiff

### DIFF
--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -436,7 +436,9 @@ class OMETiffWriter:
         writer_metadata: Dict[str, Any] = {}
 
         if baseline:
-            writer_metadata["subifds"] = num_levels - 1 if num_levels > 1 else None
+            writer_metadata["subifds"] = (
+                num_levels - 1 if num_levels > 1 and self._ome else None
+            )
         else:
             writer_metadata["subfiletype"] = tifffile.FILETYPE.REDUCEDIMAGE
 


### PR DESCRIPTION
This PR:

- Modifies the `subifds` argument in the ome-tiff writer so it can produce `generic-tiffs` which are openslide-compatible.

OME-TIFF are not compatible with OpenSlide https://github.com/cgohlke/tifffile/issues/159