### PR TITLE
Python 3.12 issue resolution and CI enrichment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         sys:
           - { os: windows-latest, shell: 'cmd /C call {0}' }
           - { os: ubuntu-24.04,  shell: "bash -l {0}" }
+        python-version: [3.9, 3.12]
       fail-fast: false
     defaults:
       run:
@@ -26,6 +27,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Install Conda environment with Micromamba
       uses: mamba-org/setup-micromamba@v2.0.2
       with:
@@ -33,7 +39,6 @@ jobs:
         environment-name: test
         cache-downloads: true
         create-args: >-
-          python=3.9
           pre-commit
           pytest-cov
           pytest-mock

--- a/tiledb/bioimg/plugin_manager.py
+++ b/tiledb/bioimg/plugin_manager.py
@@ -1,11 +1,18 @@
-import importlib.metadata
+import sys
 from typing import Any, Mapping, Type
 
 from .converters.base import ImageConverterMixin, ImageReader, ImageWriter
 
 
 def _load_entrypoints(name: str) -> Mapping[str, Any]:
-    eps = importlib.metadata.entry_points()[name]
+    if sys.version_info < (3, 12):
+        import importlib
+
+        eps = importlib.metadata.entry_points()[name]
+    else:
+        from importlib.metadata import entry_points
+
+        eps = entry_points(group=name)
     return {ep.name: ep.load() for ep in eps}
 
 


### PR DESCRIPTION
This PR:

- Introduces conditional function calls to `importlib.metadata` library according to the python version.
- Adds a CI job for running CI with `python 3.12` too.