### PR TITLE
Fix writer constructor tiff options arguments

### DIFF
--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -284,10 +284,7 @@ class ImageConverterMixin(Generic[TReader, TWriter]):
             output_config = config
 
         slide = TileDBOpenSlide(input_path, attr=attr, config=config)
-        ome = writer_kwargs.get("ome", None)
-        writer = cls._ImageWriterType(
-            destination_uri, logger, **({"ome": True if ome else None} or {})
-        )
+        writer = cls._ImageWriterType(destination_uri, logger, **(writer_kwargs or {}))
 
         with slide, writer:
             writer.write_group_metadata(slide.properties)

--- a/tiledb/bioimg/converters/base.py
+++ b/tiledb/bioimg/converters/base.py
@@ -284,7 +284,10 @@ class ImageConverterMixin(Generic[TReader, TWriter]):
             output_config = config
 
         slide = TileDBOpenSlide(input_path, attr=attr, config=config)
-        writer = cls._ImageWriterType(destination_uri, logger, **(writer_kwargs or {}))
+        ome = writer_kwargs.get("ome", None)
+        writer = cls._ImageWriterType(
+            destination_uri, logger, **({"ome": True if ome else None} or {})
+        )
 
         with slide, writer:
             writer.write_group_metadata(slide.properties)

--- a/tiledb/bioimg/converters/ome_tiff.py
+++ b/tiledb/bioimg/converters/ome_tiff.py
@@ -405,7 +405,9 @@ class OMETiffReader:
 
 
 class OMETiffWriter:
-    def __init__(self, output_path: str, logger: logging.Logger, ome: bool = True):
+    def __init__(
+        self, output_path: str, logger: logging.Logger, ome: bool = True, **kwargs: Any
+    ) -> None:
         self._logger = logger
         self._output_path = output_path
         self._ome = ome

--- a/tiledb/bioimg/converters/ome_zarr.py
+++ b/tiledb/bioimg/converters/ome_zarr.py
@@ -216,7 +216,7 @@ class OMEZarrReader:
 
 
 class OMEZarrWriter:
-    def __init__(self, output_path: str, logger: logging.Logger):
+    def __init__(self, output_path: str, logger: logging.Logger, **kwargs: Any) -> None:
         """
         OME-Zarr image writer from TileDB
 

--- a/tiledb/bioimg/converters/png.py
+++ b/tiledb/bioimg/converters/png.py
@@ -199,7 +199,7 @@ class PNGReader:
 
 class PNGWriter:
 
-    def __init__(self, output_path: str, logger: logging.Logger):
+    def __init__(self, output_path: str, logger: logging.Logger, **kwargs: Any) -> None:
         self._logger = logger
         self._output_path = output_path
         self._group_metadata: Dict[str, Any] = {}


### PR DESCRIPTION
This PR:

- Allows extra arguments to be passed into the converters constructor.
