### PR TITLE
Carrara group add members - Carrara URI support fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    name: ${{ matrix.sys.os }}
+    name: ${{ matrix.sys.os - matrix.python-version}}
     runs-on: ${{ matrix.sys.os }}
     timeout-minutes: 25
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: TileDB-BioImaging CI
 on: 
   push:
   schedule:
-    - cron: '0 6 * * 1'  # Weekly on Sunday
+    - cron: '0 6 * * 1'
 
 jobs:
   build:
@@ -83,8 +83,10 @@ jobs:
 
     - name: Run notebook examples
       run: |
-        micromamba run -n test pip install opencv-python-headless matplotlib nbmake
+        micromamba run -n test pip install opencv-python-headless matplotlib nbmake 
         micromamba run -n test pytest --nbmake examples
+      if: ${{ matrix.sys.os != 'windows-latest' }}
+
 
     - name: Create Test Coverage Badge
       if: ${{ env.run_coverage == 'true' && matrix.sys.os == 'ubuntu-24.04' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: TileDB-BioImaging CI
 
-on: [push]
+on: 
+  push:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Sunday
 
 jobs:
   build:
-    name: ${{ matrix.sys.os - matrix.python-version}}
+    name: ${{ matrix.sys.os }} ${{ matrix.python-version }}
     runs-on: ${{ matrix.sys.os }}
     timeout-minutes: 25
     strategy:

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
         "scikit-image",
         "jsonpickle",
         "requires",
+        "urllib3>=2.0",
     ],
     extras_require={
         "zarr": zarr,

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import setuptools
 
-zarr = ["ome-zarr>=0.9.0"]
+zarr = ["ome-zarr>=0.9.0,<=0.10.3"]
 openslide = ["openslide-python"]
-tiff = ["tifffile", "imagecodecs"]
+tiff = ["tifffile==v2025.5.10", "imagecodecs"]
 cloud = ["tiledb-cloud"]
 
 full = sorted({*zarr, *openslide, *tiff})
@@ -21,7 +21,6 @@ setuptools.setup(
         "scikit-image",
         "jsonpickle",
         "requires",
-        "urllib3>=2.0",
     ],
     extras_require={
         "zarr": zarr,

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -28,6 +28,7 @@ from tiledb.filter import WebpFilter
 
 from . import ATTR_NAME
 from .converters.axes import Axes, AxesMapper
+from .types import DataProtocol
 from .version import version_tuple
 
 SUPPORTED_PROTOCOLS = ("s3://", "gcs://", "azure://")
@@ -71,6 +72,53 @@ class ReadWriteGroup:
         self.w_group.close()
         self.m_group.close()
 
+    def data_protocol(self, uri: str) -> DataProtocol:
+        """Return the data protocol in use for this URI and context.
+
+        Return value will be a data model identifier. Currently one of:
+        * `tiledbv2` - the legacy data model, supported on all storage platforms except Carrara
+        * `tiledbv3` - the new, and currently Carrara-specific, data model.
+
+        Args:
+            uri:
+                An object URI
+
+        Returns:
+            The protocol identifier, currently one of `tiledbv2` or `tiledbv3`
+        ---
+
+        IMPORTANT: the API signature may change slightly in the near future
+        to align with TileDB-Py.
+
+        In addition, the implementation will evolve to use a new Core API.
+        """
+        if not uri.startswith("tiledb://"):
+            return "tiledbv2"
+
+        # The original, absolute-only, URIs had the format:
+        #     tiledb://ORG/UUID
+        # The new URIs are:
+        #     tiledb://WORKSPACE/TEAMSPACE/optional-path-elements/
+        # The current methodology to distinguish between these is to look at the run-time
+        # environment, and determine if we are running on Cloud or Carrara.
+        #
+        # NB: this method will change shortly to use a new Core API.
+
+        CLOUD_DEPLOYMENTS = {"https://api.carrara.com", "https://api.staging.tiledb.io"}
+        if self._ctx:
+            if self._ctx.config()["rest.server_address"] in CLOUD_DEPLOYMENTS:
+                return "tiledbv3"
+
+        return "tiledbv2"
+
+    def is_tiledbv2_uri(self, uri: str) -> bool:
+        """Return True if the URI will use `tiledbv2` semantics."""
+        return self.data_protocol(uri) == "tiledbv2"
+
+    def is_tiledbv3_uri(self, uri: str) -> bool:
+        """Return True if the URI will use `tiledbv3` semantics."""
+        return self.data_protocol(uri) == "tiledbv3"
+
     def get_or_create(self, name: str, schema: tiledb.ArraySchema) -> Tuple[str, bool]:
         create = False
         if name in self.r_group:
@@ -100,10 +148,15 @@ class ReadWriteGroup:
                             # (to allow the add operation)
                             self.w_group.close()
                             self.w_group.open("w")
-            # register the uri with the given name
-            if self._is_cloud:
+                            if self.is_tiledbv3_uri(uri):
+                                self.w_group.add(uri, name=uri, relative=True)
+
+            # In tiledbv3 mode, the array is created with the uri==name and relative=True and registered to the group as a member with the given name from the uri.
+            # so we don't need to add it to the group manually.
+            if self.is_tiledbv2_uri(uri):
+                # register the uri with the given name
                 self.w_group.add(uri, name, relative=False)
-            else:
+            if not self._is_cloud:
                 self.w_group.add(name, name, relative=True)
         return uri, create
 

--- a/tiledb/bioimg/helpers.py
+++ b/tiledb/bioimg/helpers.py
@@ -104,12 +104,12 @@ class ReadWriteGroup:
         #
         # NB: this method will change shortly to use a new Core API.
 
-        CLOUD_DEPLOYMENTS = {"https://api.carrara.com", "https://api.staging.tiledb.io"}
+        CLOUD_DEPLOYMENTS = {"https://api.tiledb.com", "https://api.dev.tiledb.io"}
         if self._ctx:
             if self._ctx.config()["rest.server_address"] in CLOUD_DEPLOYMENTS:
-                return "tiledbv3"
+                return "tiledbv2"
 
-        return "tiledbv2"
+        return "tiledbv3"
 
     def is_tiledbv2_uri(self, uri: str) -> bool:
         """Return True if the URI will use `tiledbv2` semantics."""
@@ -148,12 +148,12 @@ class ReadWriteGroup:
                             # (to allow the add operation)
                             self.w_group.close()
                             self.w_group.open("w")
-                            if self.is_tiledbv3_uri(uri):
+                            if self._is_cloud and self.is_tiledbv3_uri(uri):
                                 self.w_group.add(uri, name=uri, relative=True)
 
             # In tiledbv3 mode, the array is created with the uri==name and relative=True and registered to the group as a member with the given name from the uri.
-            # so we don't need to add it to the group manually.
-            if self.is_tiledbv2_uri(uri):
+            # so we don't need to add it to the group manually
+            if self._is_cloud and self.is_tiledbv2_uri(uri):
                 # register the uri with the given name
                 self.w_group.add(uri, name, relative=False)
             if not self._is_cloud:

--- a/tiledb/bioimg/types.py
+++ b/tiledb/bioimg/types.py
@@ -1,5 +1,4 @@
 import enum
-from typing import Literal
 
 
 class Converters(enum.Enum):
@@ -7,6 +6,3 @@ class Converters(enum.Enum):
     OMEZARR = enum.auto()
     OSD = enum.auto()
     PNG = enum.auto()
-
-
-DataProtocol = Literal["tiledbv2", "tiledbv3"]

--- a/tiledb/bioimg/types.py
+++ b/tiledb/bioimg/types.py
@@ -1,4 +1,5 @@
 import enum
+from typing import Literal
 
 
 class Converters(enum.Enum):
@@ -6,3 +7,6 @@ class Converters(enum.Enum):
     OMEZARR = enum.auto()
     OSD = enum.auto()
     PNG = enum.auto()
+
+
+DataProtocol = Literal["tiledbv2", "tiledbv3"]

--- a/tiledb/bioimg/wrappers.py
+++ b/tiledb/bioimg/wrappers.py
@@ -107,7 +107,6 @@ def from_bioimg(
         else:
             raise _osd_exc
     else:
-
         logger.info("Converting PNG")
         return converters["png_converter"].to_tiledb(
             source=src,


### PR DESCRIPTION
This PR:

- Removes manual membership requirement for Assets created with V3 data protocol
- Adds a helper function to identify in runtime the data_protocol used.
- Nightly CI workflow to avoid dependencies conflicts in the future.
- Pin the `tifffile` version and `Zarr` version <3.